### PR TITLE
Feature/gh2 create settings

### DIFF
--- a/.github/workflows/WP_6_4.yaml
+++ b/.github/workflows/WP_6_4.yaml
@@ -61,4 +61,4 @@ jobs:
       - name: Run Tests on Latest Version - WP6.4
         env:
           environment_github: true
-        run: composer all
+        run: composer pipeline

--- a/.github/workflows/WP_6_5.yaml
+++ b/.github/workflows/WP_6_5.yaml
@@ -61,5 +61,5 @@ jobs:
       - name: Run Tests on Latest Version - WP6.5
         env:
           environment_github: true
-        run: composer all
+        run: composer pipeline
  

--- a/.github/workflows/WP_6_6.yaml
+++ b/.github/workflows/WP_6_6.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Run Tests on Latest Version - WP6.6
         env:
           environment_github: true
-        run: composer all
+        run: composer pipeline
 
       - name: Codecov
         run: bash <(curl -s https://codecov.io/bash) -t ${{ secrets.CORE_CODEV }}

--- a/assets/src/js/dashboard.js
+++ b/assets/src/js/dashboard.js
@@ -1,0 +1,1 @@
+console.log('dashboard.js');

--- a/assets/src/js/settings.js
+++ b/assets/src/js/settings.js
@@ -1,0 +1,470 @@
+/**
+ * Settings JS
+ * 
+ * @package PinkCrab\Ecowitt_Weather_Block
+ * @license GPL-3.0-or-later
+ * @since 0.1.0
+ */
+
+// Simple functional approach for settings management
+document.addEventListener('DOMContentLoaded', function() {
+    // Use event delegation - single listener handles all clicks
+    document.addEventListener('click', handleClick);
+    
+    // Watch for new connections being added
+    const observer = new MutationObserver(handleNewConnections);
+    observer.observe(document.body, { childList: true, subtree: true });
+    
+    // Initially disable new connection form fields since form is hidden
+    enableNewConnectionFormFields(false);
+});
+
+// Constants for better maintainability
+const SELECTORS = {
+    settingsSection: '.ecowitt-settings-section',
+    connectionCard: '[id^="connection-"]',
+    connectionsContainer: '.connections-list, .ecowitt-connections',
+    viewState: '.connection__view',
+    editState: '.connection__edit',
+    newConnectionForm: '#new-connection-form',
+    newConnectionSection: '#new-connection'
+};
+
+/**
+ * Handle all clicks via event delegation
+ */
+function handleClick(event) {
+    // Prevent ANY button inside .ecowitt-settings-section from submitting forms
+    if (event.target.tagName === 'BUTTON' && event.target.closest(SELECTORS.settingsSection)) {
+        event.preventDefault();
+    }
+    
+    const action = event.target.dataset.action;
+    if (!action) return;
+    
+    switch (action) {
+        case 'edit-connection':
+            showEditMode(event.target);
+            break;
+        case 'cancel-edit':
+            showViewMode(event.target);
+            break;
+        case 'delete-connection':
+            deleteConnection(event.target);
+            break;
+        case 'show-new-connection-form':
+            showNewConnectionForm();
+            break;
+        case 'save-connection':
+            saveConnection(event.target);
+            break;
+    }
+}
+
+/**
+ * Get form field values for a connection
+ */
+function getConnectionFormData(connection) {
+    // Extract connection ID from element ID (connection-ecowitt -> ecowitt)
+    const connectionId = connection.id.replace('connection-', '');
+    
+    // Helper function to find field by multiple possible name patterns
+    const getFieldValue = (fieldPrefix) => {
+        // Try exact match first
+        let field = connection.querySelector(`[name="${fieldPrefix}[${connectionId}]"]`);
+        if (field) return field.value;
+        
+        // Try partial match for cases where ID might have changed
+        field = connection.querySelector(`[name*="${fieldPrefix}["]`);
+        if (field) return field.value;
+        
+        return '';
+    };
+    
+    // Get all form field values using exact field names
+    return {
+        connectionId: connectionId,
+        name: getFieldValue('connection_name'),
+        description: getFieldValue('connection_description'),
+        apiKey: getFieldValue('connection_api_key'),
+        apiSecret: getFieldValue('connection_api_secret'),
+        macAddress: getFieldValue('connection_mac_address')
+    };
+}
+
+/**
+ * Set form field values for a connection
+ */
+function setConnectionFormData(connection, data) {
+    const connectionId = data.connectionId;
+    
+    // Helper function to find and set field value
+    const setFieldValue = (fieldPrefix, value) => {
+        // Try exact match first
+        let field = connection.querySelector(`[name="${fieldPrefix}[${connectionId}]"]`);
+        if (!field) {
+            // Try partial match for cases where ID might have changed
+            field = connection.querySelector(`[name*="${fieldPrefix}["]`);
+        }
+        if (field) {
+            field.value = value || '';
+        }
+    };
+    
+    setFieldValue('connection_name', data.name);
+    setFieldValue('connection_description', data.description);
+    setFieldValue('connection_api_key', data.apiKey);
+    setFieldValue('connection_api_secret', data.apiSecret);
+    setFieldValue('connection_mac_address', data.macAddress);
+}
+
+/**
+ * Show edit mode for a connection
+ */
+function showEditMode(button) {
+    const connection = button.closest(SELECTORS.connectionCard);
+    if (!connection) return;
+    
+    // Cache the current form values before editing
+    connection._cachedData = getConnectionFormData(connection);
+    
+    toggleConnectionState(connection, 'edit');
+}
+
+/**
+ * Show view mode for a connection
+ */
+function showViewMode(button) {
+    const connection = button.closest(SELECTORS.connectionCard);
+    if (!connection) return;
+    
+    // Restore cached values on cancel
+    if (connection._cachedData) {
+        setConnectionFormData(connection, connection._cachedData);
+        console.log('Restored cached data for:', connection.id);
+        delete connection._cachedData;
+    }
+    
+    toggleConnectionState(connection, 'view');
+    
+    // Handle cancel on new connection form
+    const newConnectionForm = document.getElementById('new-connection-form');
+    const newConnectionSection = document.getElementById('new-connection');
+    
+    if (button.closest('#new-connection-form') && newConnectionForm && newConnectionSection) {
+        newConnectionForm.style.display = 'none';
+        newConnectionSection.style.display = 'block';
+        newConnectionForm.querySelector('form')?.reset();
+        
+        // Disable form fields so they won't be submitted
+        enableNewConnectionFormFields(false);
+    }
+}
+
+/**
+ * Toggle between view and edit states
+ */
+function toggleConnectionState(connection, state) {
+    const viewState = connection.querySelector(SELECTORS.viewState);
+    const editState = connection.querySelector(SELECTORS.editState);
+    
+    if (!viewState || !editState) return;
+    
+    if (state === 'edit') {
+        viewState.style.display = 'none';
+        editState.style.display = 'block';
+        connection.classList.add('connection--editing');
+    } else {
+        editState.style.display = 'none';
+        viewState.style.display = 'block';
+        connection.classList.remove('connection--editing');
+    }
+}
+
+/**
+ * Delete connection with confirmation
+ */
+function deleteConnection(button) {
+    const connection = button.closest(SELECTORS.connectionCard);
+    if (!connection) return;
+    
+    if (confirm('Are you sure you want to delete this connection?')) {
+        console.log('Connection deleted:', connection.id);
+        connection.remove();
+    }
+}
+
+/**
+ * Show new connection form
+ */
+function showNewConnectionForm() {
+    const newConnectionSection = document.querySelector(SELECTORS.newConnectionSection);
+    const newConnectionForm = document.querySelector(SELECTORS.newConnectionForm);
+    
+    if (newConnectionSection && newConnectionForm) {
+        newConnectionSection.style.display = 'none';
+        newConnectionForm.style.display = 'block';
+        
+        // Show the edit section
+        const editSection = newConnectionForm.querySelector(SELECTORS.editState);
+        if (editSection) {
+            editSection.style.display = 'block';
+        }
+        
+        // Enable form fields so they can be used for creating new connections
+        enableNewConnectionFormFields(true);
+    }
+}
+
+/**
+ * Update view elements with form data
+ */
+function updateConnectionView(connection, formData) {
+    const viewState = connection.querySelector('.connection__view');
+    if (!viewState) return;
+    
+    // Update connection title
+    const titleElement = viewState.querySelector('.connection__title');
+    if (titleElement) {
+        titleElement.textContent = formData.name || 'Unnamed Connection';
+    }
+    
+    // Update description
+    const descriptionElement = viewState.querySelector('.connection__description');
+    if (formData.description) {
+        if (descriptionElement) {
+            descriptionElement.textContent = formData.description;
+            descriptionElement.style.display = 'block';
+        } else {
+            // Create description element if it doesn't exist
+            const content = viewState.querySelector('.connection__content');
+            if (content) {
+                const newDesc = document.createElement('p');
+                newDesc.className = 'connection__description';
+                newDesc.textContent = formData.description;
+                content.insertBefore(newDesc, content.querySelector('.connection__details'));
+            }
+        }
+    } else if (descriptionElement) {
+        descriptionElement.style.display = 'none';
+    }
+    
+    // Update API Key (masked)
+    const apiKeyElement = viewState.querySelector('.connection__details .detail__value--masked[title*="••••"]');
+    if (apiKeyElement && formData.apiKey) {
+        const maskedKey = formData.apiKey.substring(0, 4) + '••••••••';
+        apiKeyElement.textContent = maskedKey;
+        apiKeyElement.title = maskedKey;
+    }
+    
+    // Update API Secret (masked) - find the second masked element
+    const maskedElements = viewState.querySelectorAll('.detail__value--masked');
+    if (maskedElements.length > 1 && formData.apiSecret) {
+        const maskedSecret = formData.apiSecret.substring(0, 4) + '••••••••';
+        maskedElements[1].textContent = maskedSecret;
+        maskedElements[1].title = maskedSecret;
+    }
+    
+    // Update MAC Address
+    const macElement = viewState.querySelector('.detail__value:not(.detail__value--masked)');
+    if (macElement && formData.macAddress) {
+        macElement.textContent = formData.macAddress;
+    }
+    
+    // Update connection status if all required fields are filled
+    const statusElement = viewState.querySelector('.connection__status');
+    if (statusElement) {
+        const isActive = formData.name && formData.apiKey && formData.apiSecret && formData.macAddress;
+        statusElement.textContent = isActive ? 'Connected' : 'Not Configured';
+        
+        // Update connection card class
+        connection.classList.remove('connection--active', 'connection--inactive');
+        connection.classList.add(isActive ? 'connection--active' : 'connection--inactive');
+    }
+}
+
+/**
+ * Save connection
+ */
+function saveConnection(button) {
+    const connection = button.closest(SELECTORS.connectionCard);
+    if (!connection) return;
+    
+    // Check if this is a new connection (either __new_ or connection-__new_)
+    if (connection.id === 'connection-__new_' || connection.id.includes('__new_')) {
+        createNewConnection(connection);
+        return;
+    }
+    
+    // Handle existing connection update
+    const formData = getConnectionFormData(connection);
+    console.log('Saving connection:', connection.id, formData);
+    
+    // Update the view with new values
+    updateConnectionView(connection, formData);
+    
+    // Clean up cached data since we're saving
+    delete connection._cachedData;
+    
+    // Switch back to view mode
+    toggleConnectionState(connection, 'view');
+}
+
+/**
+ * Create a new connection from the template
+ */
+function createNewConnection(newConnectionElement) {
+    // Generate unique ID with better uniqueness guarantee
+    const timestamp = Date.now();
+    const random = Math.floor(Math.random() * 1000000); // 0-999999
+    const uniqueId = `__new_${timestamp}_${random}`;
+    
+    console.log('Creating new connection with ID:', uniqueId);
+    
+    // Get form data from the new connection form - be more flexible in finding fields
+    const getFieldValue = (fieldPattern) => {
+        const field = newConnectionElement.querySelector(`[name*="${fieldPattern}"]`);
+        return field ? field.value : '';
+    };
+    
+    const formData = {
+        name: getFieldValue('connection_name'),
+        description: getFieldValue('connection_description'),
+        apiKey: getFieldValue('connection_api_key'),
+        apiSecret: getFieldValue('connection_api_secret'),
+        macAddress: getFieldValue('connection_mac_address')
+    };
+    
+    console.log('Form data:', formData);
+    
+    // Validate required fields
+    if (!formData.name || !formData.apiKey || !formData.apiSecret || !formData.macAddress) {
+        alert('Please fill in all required fields (Name, API Key, API Secret, and MAC Address)');
+        return;
+    }
+    
+    // Get the connection template from localized data
+    if (!window.ecowittSettings?.connectionTemplate) {
+        console.error('Connection template not available');
+        return;
+    }
+    
+    // Replace template placeholders with actual values
+    let connectionHtml = window.ecowittSettings.connectionTemplate
+        .replace(/{key}/g, uniqueId)
+        .replace(/{name}/g, formData.name || 'Unnamed Connection')
+        .replace(/{description}/g, formData.description || '')
+        .replace(/{api_key}/g, formData.apiKey)
+        .replace(/{api_secret}/g, formData.apiSecret)
+        .replace(/{mac_address}/g, formData.macAddress);
+    
+    // Create masked versions for display
+    const maskedApiKey = formData.apiKey ? formData.apiKey.substring(0, 4) + '••••••••' : '';
+    const maskedApiSecret = formData.apiSecret ? formData.apiSecret.substring(0, 4) + '••••••••' : '';
+    
+    // Replace masked placeholders
+    connectionHtml = connectionHtml.replace(/{api_key_masked}/g, maskedApiKey);
+    connectionHtml = connectionHtml.replace(/{api_secret_masked}/g, maskedApiSecret);
+    
+    // Find the connections container and add the new connection
+    const connectionsContainer = document.querySelector(SELECTORS.connectionsContainer);
+    if (!connectionsContainer) {
+        console.error('Connections container not found');
+        return;
+    }
+    
+    // Create and add the new connection
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = connectionHtml;
+    const newConnectionCard = tempDiv.firstElementChild;
+    
+    // Ensure the connection has the correct ID
+    newConnectionCard.id = `connection-${uniqueId}`;
+    
+    // Update all form field names to use the new unique ID
+    updateConnectionFieldNames(newConnectionCard, uniqueId);
+    
+    // Add to the connections container
+    connectionsContainer.appendChild(newConnectionCard);
+    
+    // Update the connection view with the form data
+    updateConnectionView(newConnectionCard, formData);
+    
+    // Ensure the connection is in view mode (not edit mode)
+    toggleConnectionState(newConnectionCard, 'view');
+    
+    // Hide the new connection form and show the "Add New" button
+    const newConnectionForm = document.querySelector(SELECTORS.newConnectionForm);
+    const newConnectionSection = document.querySelector(SELECTORS.newConnectionSection);
+    
+    if (newConnectionForm && newConnectionSection) {
+        newConnectionForm.style.display = 'none';
+        newConnectionSection.style.display = 'block';
+        newConnectionForm.querySelector('form')?.reset();
+        
+        // Disable form fields so they won't be submitted
+        enableNewConnectionFormFields(false);
+    }
+    
+    console.log('New connection created with ID:', uniqueId);
+}
+
+/**
+ * Update all form field names in a connection to use the correct unique ID
+ */
+function updateConnectionFieldNames(connectionElement, uniqueId) {
+    const fieldsToUpdate = [
+        'connection_key',
+        'connection_name', 
+        'connection_description',
+        'connection_api_key',
+        'connection_api_secret', 
+        'connection_mac_address'
+    ];
+    
+    fieldsToUpdate.forEach(fieldName => {
+        const field = connectionElement.querySelector(`[name*="${fieldName}"]`);
+        if (field) {
+            field.name = `${fieldName}[${uniqueId}]`;
+            
+            // Remove any validation attributes that might cause issues
+            field.removeAttribute('required');
+            field.removeAttribute('pattern');
+            
+            console.log(`Updated field name to: ${field.name}`);
+        }
+    });
+}/**
+ * Enable or disable new connection form fields
+ */
+function enableNewConnectionFormFields(enable) {
+    const newConnectionForm = document.querySelector(SELECTORS.newConnectionForm);
+    if (!newConnectionForm) return;
+    
+    // Find all form fields in the new connection form
+    const fields = newConnectionForm.querySelectorAll('input[name*="[__new_]"]');
+    
+    fields.forEach(field => {
+        if (enable) {
+            field.removeAttribute('disabled');
+        } else {
+            field.setAttribute('disabled', 'disabled');
+        }
+    });
+    
+    console.log(`${enable ? 'Enabled' : 'Disabled'} ${fields.length} new connection form fields`);
+}
+
+/**
+ * Handle new connections being added to DOM
+ */
+function handleNewConnections(mutations) {
+    mutations.forEach(mutation => {
+        mutation.addedNodes.forEach(node => {
+            if (node.nodeType === Node.ELEMENT_NODE && node.matches && node.matches('[id^="connection-"]')) {
+                // New connection added - no extra setup needed with event delegation
+                console.log('New connection detected:', node.id);
+            }
+        });
+    });
+}

--- a/assets/src/js/settings_OLD.js
+++ b/assets/src/js/settings_OLD.js
@@ -1,0 +1,583 @@
+/**
+ * Settings JS
+ * 
+ * @package PinkCrab\Ecowitt_Weather_Block
+ * @license GPL-3.0-or-later
+ * @since 0.1.0
+ */
+
+console.log('settings.js');
+
+/**
+ * Main Settings Manager
+ * Handles all settings page interactions including dynamic connection panels
+ */
+class SettingsManager {
+    constructor() {
+        this.connections = new Map();
+        this.observer = null;
+        this.init();
+    }
+
+    /**
+     * Initialize the settings manager
+     */
+    init() {
+        this.setupMutationObserver();
+        this.initializeExistingConnections();
+        this.initializeNewConnectionForm();
+    }
+
+    /**
+     * Setup mutation observer to watch for dynamically added connections
+     */
+    setupMutationObserver() {
+        this.observer = new MutationObserver((mutations) => {
+            mutations.forEach((mutation) => {
+                mutation.addedNodes.forEach((node) => {
+                    if (node.nodeType === Node.ELEMENT_NODE) {
+                        // Check if the added node is a connection card
+                        if (node.matches && node.matches('[id^="connection-"]')) {
+                            this.initializeConnection(node);
+                        }
+                        // Check for connection cards within the added node
+                        const connectionCards = node.querySelectorAll && node.querySelectorAll('[id^="connection-"]');
+                        if (connectionCards) {
+                            connectionCards.forEach(card => this.initializeConnection(card));
+                        }
+                    }
+                });
+            });
+        });
+
+        // Start observing
+        this.observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+    }
+
+    /**
+     * Initialize existing connections on page load
+     */
+    initializeExistingConnections() {
+        const existingConnections = document.querySelectorAll('[id^="connection-"]');
+        existingConnections.forEach(card => this.initializeConnection(card));
+    }
+
+    /**
+     * Initialize new connection form functionality
+     */
+    initializeNewConnectionForm() {
+        const showFormBtn = document.querySelector('[data-action="show-new-connection-form"]');
+        const newConnectionSection = document.getElementById('new-connection');
+        const newConnectionForm = document.getElementById('new-connection-form');
+        
+        if (showFormBtn && newConnectionSection && newConnectionForm) {
+            showFormBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.showNewConnectionForm(newConnectionSection, newConnectionForm);
+            });
+        }
+
+        // Also look for cancel button in new connection form
+        const cancelBtn = newConnectionForm && newConnectionForm.querySelector('[data-action="cancel-edit"]');
+        if (cancelBtn && newConnectionSection && newConnectionForm) {
+            cancelBtn.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.hideNewConnectionForm(newConnectionSection, newConnectionForm);
+            });
+        }
+    }
+
+    /**
+     * Show the new connection form
+     * @param {HTMLElement} newConnectionSection 
+     * @param {HTMLElement} newConnectionForm 
+     */
+    showNewConnectionForm(newConnectionSection, newConnectionForm) {
+        newConnectionSection.style.display = 'none';
+        newConnectionForm.style.display = 'block';
+        newConnectionForm.classList.add('is-active');
+        
+        // Force the connection edit section to show using CSS
+        const style = document.createElement('style');
+        style.id = 'new-connection-form-style';
+        style.textContent = '#new-connection-form .connection__edit { display: block !important; }';
+        document.head.appendChild(style);
+        
+        // Trigger custom event
+        document.dispatchEvent(new CustomEvent('connection:new-form-shown', {
+            detail: { newConnectionForm }
+        }));
+    }
+
+    /**
+     * Hide the new connection form
+     * @param {HTMLElement} newConnectionSection 
+     * @param {HTMLElement} newConnectionForm 
+     */
+    hideNewConnectionForm(newConnectionSection, newConnectionForm) {
+        newConnectionForm.style.display = 'none';
+        newConnectionForm.classList.remove('is-active');
+        newConnectionSection.style.display = 'block';
+        
+        // Remove the CSS override style
+        const style = document.getElementById('new-connection-form-style');
+        if (style) {
+            style.remove();
+        }
+        
+        // Clear form data if needed
+        const form = newConnectionForm.querySelector('form');
+        if (form) {
+            form.reset();
+        }
+        
+        // Trigger custom event
+        document.dispatchEvent(new CustomEvent('connection:new-form-hidden', {
+            detail: { newConnectionSection }
+        }));
+    }
+
+    /**
+     * Initialize a single connection card
+     * @param {HTMLElement} connectionCard 
+     */
+    initializeConnection(connectionCard) {
+        if (!connectionCard || !connectionCard.id) return;
+
+        const connectionId = this.extractConnectionId(connectionCard.id);
+        
+        // Skip if already initialized
+        if (this.connections.has(connectionId)) return;
+
+        const connectionHandler = new ConnectionHandler(connectionCard, connectionId);
+        this.connections.set(connectionId, connectionHandler);
+    }
+
+    /**
+     * Extract connection ID from element ID
+     * @param {string} elementId 
+     * @returns {string}
+     */
+    extractConnectionId(elementId) {
+        return elementId.replace('connection-', '');
+    }
+
+    /**
+     * Remove a connection from the manager
+     * @param {string} connectionId 
+     */
+    removeConnection(connectionId) {
+        const handler = this.connections.get(connectionId);
+        if (handler) {
+            handler.destroy();
+            this.connections.delete(connectionId);
+        }
+    }
+
+    /**
+     * Handle saving a new connection
+     * @param {string} connectionId 
+     * @param {Object} formData 
+     * @param {HTMLElement} connectionCard 
+     */
+    handleNewConnectionSave(connectionId, formData, connectionCard) {
+        // Use HTML5 form validation instead of manual validation
+        const form = connectionCard.querySelector('form');
+        if (form && !form.checkValidity()) {
+            // If form is invalid, show validation messages and stop
+            form.reportValidity();
+            return;
+        }
+
+        // Generate a new connection ID (replace the temporary one)
+        const newConnectionId = 'connection_' + Date.now() + '_' + Math.random().toString(36).substr(2, 9);
+        
+        // Get the connection template
+        const template = window.ecowittSettings?.connectionTemplate;
+        if (!template) {
+            console.error('Connection template not available');
+            return;
+        }
+
+        // Replace template variables with actual values
+        let connectionHtml = template
+            .replace(/\{key\}/g, newConnectionId)
+            .replace(/\{name\}/g, formData[`connection_name[${connectionId}]`] || '')
+            .replace(/\{description\}/g, formData[`connection_description[${connectionId}]`] || '')
+            .replace(/\{api_key\}/g, formData[`connection_api_key[${connectionId}]`] || '')
+            .replace(/\{api_secret\}/g, formData[`connection_api_secret[${connectionId}]`] || '')
+            .replace(/\{mac_address\}/g, formData[`connection_mac_address[${connectionId}]`] || '');
+
+        // Find or create the connections list
+        let connectionsList = document.querySelector('.connections-list');
+        if (!connectionsList) {
+            // If no connections exist, we need to replace the empty state
+            const connectionsContainer = document.querySelector('.connections-container');
+            const emptyState = connectionsContainer.querySelector('.connections-empty');
+            
+            if (emptyState) {
+                emptyState.remove();
+            }
+            
+            // Create the connections list
+            connectionsList = document.createElement('div');
+            connectionsList.className = 'connections-list';
+            connectionsContainer.insertBefore(connectionsList, connectionsContainer.querySelector('.new-connection'));
+        }
+
+        // Add the new connection to the list
+        connectionsList.insertAdjacentHTML('beforeend', connectionHtml);
+
+        // Hide the new connection form
+        const newConnectionSection = document.getElementById('new-connection');
+        const newConnectionForm = document.getElementById('new-connection-form');
+        this.hideNewConnectionForm(newConnectionSection, newConnectionForm);
+
+        // Initialize the new connection (it will be picked up by the mutation observer automatically)
+        // But we can also manually trigger it for immediate functionality
+        const newConnectionCard = document.getElementById('connection-' + newConnectionId);
+        if (newConnectionCard) {
+            this.initializeConnection(newConnectionCard);
+        }
+
+        // Trigger success event
+        document.dispatchEvent(new CustomEvent('connection:new-connection-added', {
+            detail: { 
+                connectionId: newConnectionId,
+                formData: formData,
+                connectionCard: newConnectionCard
+            }
+        }));
+
+        console.log('New connection added:', newConnectionId);
+    }
+
+    /**
+     * Cleanup when needed
+     */
+    destroy() {
+        if (this.observer) {
+            this.observer.disconnect();
+        }
+        this.connections.forEach(handler => handler.destroy());
+        this.connections.clear();
+    }
+}
+
+/**
+ * Connection Handler
+ * Manages individual connection panel interactions
+ */
+class ConnectionHandler {
+    constructor(connectionCard, connectionId) {
+        this.connectionCard = connectionCard;
+        this.connectionId = connectionId;
+        this.elements = {};
+        this.eventListeners = [];
+        
+        this.init();
+    }
+
+    /**
+     * Initialize the connection handler
+     */
+    init() {
+        this.cacheElements();
+        this.bindEvents();
+    }
+
+    /**
+     * Cache DOM elements for this connection
+     */
+    cacheElements() {
+        this.elements = {
+            viewState: this.connectionCard.querySelector('.connection__view'),
+            editState: this.connectionCard.querySelector('.connection__edit'),
+            editBtn: this.connectionCard.querySelector('[data-action="edit-connection"]'),
+            cancelBtn: this.connectionCard.querySelector('[data-action="cancel-edit"]'),
+            deleteBtn: this.connectionCard.querySelector('[data-action="delete-connection"]'),
+            saveBtn: this.connectionCard.querySelector('[data-action="save-connection"]')
+        };
+
+        // Ensure save button is not a submit type to prevent form submission
+        const { saveBtn } = this.elements;
+        if (saveBtn && saveBtn.type === 'submit') {
+            saveBtn.type = 'button';
+            console.log('Changed save button type from submit to button');
+        }
+    }
+
+    /**
+     * Bind event listeners
+     */
+    bindEvents() {
+        this.bindEditConnection();
+        this.bindCancelEdit();
+        this.bindDeleteConnection();
+        this.bindSaveConnection();
+    }
+
+    /**
+     * Bind edit connection functionality
+     */
+    bindEditConnection() {
+        const { editBtn, editState, viewState } = this.elements;
+        
+        if (editBtn && editState && viewState) {
+            const handler = (e) => {
+                e.preventDefault();
+                this.enterEditMode();
+            };
+            
+            editBtn.addEventListener('click', handler);
+            this.eventListeners.push({ element: editBtn, event: 'click', handler });
+        }
+    }
+
+    /**
+     * Bind cancel edit functionality
+     */
+    bindCancelEdit() {
+        const { cancelBtn, editState, viewState } = this.elements;
+        
+        if (cancelBtn && editState && viewState) {
+            const handler = (e) => {
+                e.preventDefault();
+                this.exitEditMode();
+            };
+            
+            cancelBtn.addEventListener('click', handler);
+            this.eventListeners.push({ element: cancelBtn, event: 'click', handler });
+        }
+    }
+
+    /**
+     * Bind delete connection functionality
+     */
+    bindDeleteConnection() {
+        const { deleteBtn } = this.elements;
+        
+        if (deleteBtn) {
+            const handler = (e) => {
+                e.preventDefault();
+                this.handleDelete();
+            };
+            
+            deleteBtn.addEventListener('click', handler);
+            this.eventListeners.push({ element: deleteBtn, event: 'click', handler });
+        }
+    }
+
+    /**
+     * Bind save connection functionality
+     */
+    bindSaveConnection() {
+        const { saveBtn } = this.elements;
+        
+        if (saveBtn) {
+            const handler = (e) => {
+                console.log('Save button clicked, preventing default');
+                e.preventDefault();
+                e.stopPropagation();
+                e.stopImmediatePropagation();
+                this.handleSave();
+                return false;
+            };
+            
+            saveBtn.addEventListener('click', handler);
+            this.eventListeners.push({ element: saveBtn, event: 'click', handler });
+        }
+
+        // Also bind to form submission to catch any other submit triggers
+        const form = this.connectionCard.querySelector('form');
+        if (form) {
+            const formHandler = (e) => {
+                console.log('Form submit triggered, preventing default');
+                e.preventDefault();
+                e.stopPropagation();
+                e.stopImmediatePropagation();
+                this.handleSave();
+                return false;
+            };
+            
+            form.addEventListener('submit', formHandler);
+            this.eventListeners.push({ element: form, event: 'submit', handler: formHandler });
+        }
+    }
+
+    /**
+     * Enter edit mode
+     */
+    enterEditMode() {
+        const { viewState, editState } = this.elements;
+        
+        if (viewState && editState) {
+            viewState.style.display = 'none';
+            editState.style.display = 'block';
+            this.connectionCard.classList.add('connection--editing');
+            
+            // Trigger custom event
+            this.triggerEvent('connection:edit-mode-entered', { connectionId: this.connectionId });
+        }
+    }
+
+    /**
+     * Exit edit mode
+     */
+    exitEditMode() {
+        const { viewState, editState } = this.elements;
+        
+        if (viewState && editState) {
+            editState.style.display = 'none';
+            viewState.style.display = 'block';
+            this.connectionCard.classList.remove('connection--editing');
+            
+            // Trigger custom event
+            this.triggerEvent('connection:edit-mode-exited', { connectionId: this.connectionId });
+        }
+    }
+
+    /**
+     * Handle connection deletion
+     */
+    handleDelete() {
+        // Get confirmation message from data attribute or use default
+        const confirmMessage = this.connectionCard.dataset.deleteConfirmMessage || 
+                              'Are you sure you want to delete this connection?';
+        
+        if (confirm(confirmMessage)) {
+            // Trigger custom event for deletion
+            this.triggerEvent('connection:delete-requested', { 
+                connectionId: this.connectionId,
+                connectionCard: this.connectionCard 
+            });
+            
+            console.log('Delete connection requested:', this.connectionId);
+            
+            // You can implement actual deletion logic here
+            // or listen for the custom event elsewhere in your code
+        }
+    }
+
+    /**
+     * Handle connection save
+     */
+    handleSave() {
+        // First, ensure the edit state is visible for validation
+        const { viewState, editState } = this.elements;
+        if (editState && editState.style.display === 'none') {
+            // Temporarily show the edit state for validation
+            const wasHidden = true;
+            editState.style.display = 'block';
+            if (viewState) viewState.style.display = 'none';
+        }
+
+        // Check form validity first
+        const form = this.connectionCard.querySelector('form');
+        if (form && !form.checkValidity()) {
+            // If form is invalid, show validation messages and stop
+            form.reportValidity();
+            return;
+        }
+
+        // Collect form data
+        const formData = this.collectFormData();
+        
+        // Trigger custom event for save
+        this.triggerEvent('connection:save-requested', { 
+            connectionId: this.connectionId,
+            formData: formData,
+            connectionCard: this.connectionCard 
+        });
+        
+        console.log('Save connection requested:', this.connectionId, formData);
+    }
+
+    /**
+     * Collect form data from the edit state
+     * @returns {Object}
+     */
+    collectFormData() {
+        const { editState } = this.elements;
+        const formData = {};
+        
+        if (editState) {
+            const inputs = editState.querySelectorAll('input, select, textarea');
+            inputs.forEach(input => {
+                if (input.name) {
+                    formData[input.name] = input.value;
+                }
+            });
+        }
+        
+        return formData;
+    }
+
+    /**
+     * Trigger a custom event
+     * @param {string} eventName 
+     * @param {Object} detail 
+     */
+    triggerEvent(eventName, detail = {}) {
+        const event = new CustomEvent(eventName, {
+            detail: detail,
+            bubbles: true,
+            cancelable: true
+        });
+        
+        this.connectionCard.dispatchEvent(event);
+    }
+
+    /**
+     * Clean up event listeners
+     */
+    destroy() {
+        this.eventListeners.forEach(({ element, event, handler }) => {
+            element.removeEventListener(event, handler);
+        });
+        this.eventListeners = [];
+    }
+}
+
+/**
+ * Initialize settings manager when DOM is ready
+ */
+document.addEventListener('DOMContentLoaded', function() {
+    window.EcowittSettingsManager = new SettingsManager();
+    
+    // Example: Listen for custom events
+    document.addEventListener('connection:delete-requested', function(e) {
+        const { connectionId, connectionCard } = e.detail;
+        
+        // Implement your deletion logic here
+        // This could involve AJAX calls to your backend
+        console.log('Handling deletion for connection:', connectionId);
+        
+        // Example: Remove from DOM after successful deletion
+        // connectionCard.remove();
+        // window.EcowittSettingsManager.removeConnection(connectionId);
+    });
+    
+    document.addEventListener('connection:save-requested', function(e) {
+        const { connectionId, formData } = e.detail;
+        
+        // Check if this is a new connection (starts with 'new_')
+        if (connectionId.startsWith('new_')) {
+            // Handle new connection save
+            window.EcowittSettingsManager.handleNewConnectionSave(connectionId, formData, e.detail.connectionCard);
+        } else {
+            // Handle existing connection save
+            console.log('Handling save for existing connection:', connectionId, formData);
+        }
+    });
+});
+
+// Cleanup on page unload
+window.addEventListener('beforeunload', function() {
+    if (window.EcowittSettingsManager) {
+        window.EcowittSettingsManager.destroy();
+    }
+});

--- a/assets/src/scss/abstracts/_mixins.scss
+++ b/assets/src/scss/abstracts/_mixins.scss
@@ -1,0 +1,258 @@
+/**
+ * Mixins
+ * 
+ * Reusable SCSS mixins for common patterns and utilities.
+ */
+
+@use 'sass:map';
+// ==========================================================================
+// RESPONSIVE MIXINS
+// ==========================================================================
+/// Responsive breakpoint mixin
+/// @param {String} $breakpoint - Breakpoint name
+/// @param {String} $direction [up] - Direction (up, down, only)
+@mixin breakpoint($breakpoint, $direction: 'up') {
+    $value: map.get($breakpoints, $breakpoint);
+    @if $direction=='up' {
+        @media (min-width: $value) {
+            @content;
+        }
+    }
+    @else if $direction=='down' {
+        @media (max-width: calc(#{$value} - 1px)) {
+            @content;
+        }
+    }
+}
+
+/// Container mixin with max-width and auto margins
+/// @param {Number} $max-width [$container-max-width] - Maximum width
+@mixin container($max-width: $container-max-width) {
+    width: 100%;
+    max-width: $max-width;
+    margin-left: auto;
+    margin-right: auto;
+    padding-left: var(--wp-spacing-md);
+    padding-right: var(--wp-spacing-md);
+}
+
+// ==========================================================================
+// LAYOUT MIXINS
+// ==========================================================================
+/// Flexbox utilities
+@mixin flex-center {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+@mixin flex-between {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+@mixin flex-column {
+    display: flex;
+    flex-direction: column;
+}
+
+/// Grid utilities
+@mixin grid($columns: 1, $gap: var(--wp-spacing-md)) {
+    display: grid;
+    grid-template-columns: repeat($columns, 1fr);
+    gap: $gap;
+}
+
+/// Aspect ratio
+@mixin aspect-ratio($width, $height) {
+    aspect-ratio: $width / $height;
+    // Fallback for older browsers
+    @supports not (aspect-ratio: 1 / 1) {
+        position: relative;
+        &::before {
+            content: '';
+            display: block;
+            padding-top: percentage($height / $width);
+        }
+    }
+}
+
+// ==========================================================================
+// TYPOGRAPHY MIXINS
+// ==========================================================================
+/// Text truncation
+@mixin truncate {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/// Multi-line text truncation
+/// @param {Number} $lines [2] - Number of lines to show
+@mixin line-clamp($lines: 2) {
+    display: -webkit-box;
+    -webkit-line-clamp: $lines;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+/// Screen reader only content
+@mixin sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+// ==========================================================================
+// COMPONENT MIXINS
+// ==========================================================================
+/// Button base styles
+@mixin button-base {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--wp-spacing-xs);
+    padding: $button-padding-y $button-padding-x;
+    border: var(--wp-border-width) solid transparent;
+    border-radius: $button-border-radius;
+    font-family: var(--wp-font-family);
+    font-size: var(--wp-font-size-base);
+    font-weight: $button-font-weight;
+    line-height: 1;
+    text-decoration: none;
+    cursor: pointer;
+    transition: all var(--wp-transition);
+    user-select: none;
+    &:focus {
+        outline: 2px solid var(--wp-color-primary);
+        outline-offset: 2px;
+    }
+    &:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+    }
+}
+
+/// Button variant styles
+/// @param {Color} $bg - Background color
+/// @param {Color} $color - Text color
+/// @param {Color} $border [$bg] - Border color
+/// @param {Color} $hover-bg [darken($bg, 10%)] - Hover background
+/// @param {Color} $hover-color [$color] - Hover text color
+@mixin button-variant($bg, $color, $border: $bg, $hover-bg: null, $hover-color: null) {
+    background-color: $bg;
+    color: $color;
+    border-color: $border;
+    @if $hover-bg==null {
+        $hover-bg: color-mix(in srgb, $bg 85%, black);
+    }
+    @if $hover-color==null {
+        $hover-color: $color;
+    }
+    &:hover:not(:disabled) {
+        background-color: $hover-bg;
+        color: $hover-color;
+        border-color: $hover-bg;
+    }
+}
+
+/// Card component
+@mixin card {
+    background: var(--wp-card-bg);
+    border: var(--wp-card-border);
+    border-radius: var(--wp-card-border-radius);
+    box-shadow: var(--wp-card-shadow);
+    padding: var(--wp-card-padding);
+}
+
+/// Form field base
+@mixin form-field {
+    width: 100%;
+    padding: $form-field-padding-y $form-field-padding-x;
+    border: $form-field-border;
+    border-radius: $form-field-border-radius;
+    font-family: var(--wp-font-family);
+    font-size: $form-field-font-size;
+    line-height: var(--wp-line-height-normal);
+    background-color: var(--wp-color-white);
+    transition: border-color var(--wp-transition);
+    &:focus {
+        outline: none;
+        border-color: var(--wp-color-primary);
+        box-shadow: 0 0 0 1px var(--wp-color-primary);
+    }
+    &:disabled {
+        background-color: var(--wp-color-gray-100);
+        color: var(--wp-color-gray-500);
+        cursor: not-allowed;
+    }
+    &::placeholder {
+        color: var(--wp-color-gray-400);
+    }
+}
+
+// ==========================================================================
+// UTILITY MIXINS
+// ==========================================================================
+/// Generate utility classes
+/// @param {String} $property - CSS property
+/// @param {Map} $values - Map of value names and values
+/// @param {String} $prefix [''] - Class prefix
+@mixin generate-utilities($property, $values, $prefix: '') {
+    @each $name,
+    $value in $values {
+        .#{$prefix}#{$name} {
+            #{$property}: #{$value};
+        }
+    }
+}
+
+/// Hover media query (respects user preferences)
+@mixin hover {
+    @media (hover: hover) {
+        &:hover {
+            @content;
+        }
+    }
+}
+
+/// Focus visible styles
+@mixin focus-visible {
+    &:focus-visible {
+        @content;
+    }
+    // Fallback for browsers without :focus-visible
+    @supports not selector(:focus-visible) {
+        &:focus {
+            @content;
+        }
+    }
+}
+
+/// High contrast mode support
+@mixin high-contrast {
+    @media (prefers-contrast: high) {
+        @content;
+    }
+}
+
+/// Reduced motion support
+@mixin reduced-motion {
+    @media (prefers-reduced-motion: reduce) {
+        @content;
+    }
+}
+
+/// Dark mode support (if WordPress ever adds it)
+@mixin dark-mode {
+    @media (prefers-color-scheme: dark) {
+        @content;
+    }
+}

--- a/assets/src/scss/abstracts/_variables.scss
+++ b/assets/src/scss/abstracts/_variables.scss
@@ -1,0 +1,149 @@
+/**
+ * Variables
+ * 
+ * WordPress-compatible design tokens that respect user preferences
+ * and provide a solid foundation for the admin interface.
+ */
+
+// ==========================================================================
+// WORDPRESS ADMIN INTEGRATION
+// ==========================================================================
+:root {
+    // WordPress admin colors (these are available in WP admin)
+    --wp-color-primary: #2271b1;
+    --wp-color-primary-hover: #135e96;
+    --wp-color-primary-focus: #043959;
+    --wp-color-success: #00a32a;
+    --wp-color-success-hover: #008a20;
+    --wp-color-warning: #dba617;
+    --wp-color-warning-hover: #c9a214;
+    --wp-color-danger: #d63638;
+    --wp-color-danger-hover: #b32d2e;
+    --wp-color-info: #72aee6;
+    --wp-color-info-hover: #3582c4;
+    // WordPress neutral colors
+    --wp-color-white: #ffffff;
+    --wp-color-gray-50: #f6f7f7;
+    --wp-color-gray-100: #f0f0f1;
+    --wp-color-gray-200: #dcdcde;
+    --wp-color-gray-300: #c3c4c7;
+    --wp-color-gray-400: #a7aaad;
+    --wp-color-gray-500: #8c8f94;
+    --wp-color-gray-600: #646970;
+    --wp-color-gray-700: #3c434a;
+    --wp-color-gray-800: #1d2327;
+    --wp-color-gray-900: #000000;
+    // WordPress typography
+    --wp-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+    --wp-font-family-mono: Consolas, Monaco, monospace;
+    // WordPress spacing (8px grid)
+    --wp-spacing-unit: 8px;
+    --wp-spacing-xs: calc(var(--wp-spacing-unit) * 0.5); // 4px
+    --wp-spacing-sm: var(--wp-spacing-unit); // 8px
+    --wp-spacing-md: calc(var(--wp-spacing-unit) * 2); // 16px
+    --wp-spacing-lg: calc(var(--wp-spacing-unit) * 3); // 24px
+    --wp-spacing-xl: calc(var(--wp-spacing-unit) * 4); // 32px
+    --wp-spacing-xxl: calc(var(--wp-spacing-unit) * 6); // 48px
+    // WordPress font sizes
+    --wp-font-size-xs: 11px;
+    --wp-font-size-sm: 12px;
+    --wp-font-size-base: 13px;
+    --wp-font-size-md: 14px;
+    --wp-font-size-lg: 18px;
+    --wp-font-size-xl: 24px;
+    --wp-font-size-xxl: 32px;
+    // WordPress font weights
+    --wp-font-weight-normal: 400;
+    --wp-font-weight-medium: 500;
+    --wp-font-weight-semibold: 600;
+    --wp-font-weight-bold: 700;
+    // WordPress line heights
+    --wp-line-height-tight: 1.2;
+    --wp-line-height-normal: 1.4;
+    --wp-line-height-relaxed: 1.6;
+    // WordPress borders & radius
+    --wp-border-width: 1px;
+    --wp-border-color: var(--wp-color-gray-300);
+    --wp-border-radius-sm: 3px;
+    --wp-border-radius: 4px;
+    --wp-border-radius-lg: 6px;
+    --wp-border-radius-xl: 8px;
+    // WordPress shadows
+    --wp-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.13);
+    --wp-shadow: 0 1px 3px rgba(0, 0, 0, 0.13);
+    --wp-shadow-md: 0 3px 6px rgba(0, 0, 0, 0.16);
+    --wp-shadow-lg: 0 5px 15px rgba(0, 0, 0, 0.08);
+    // WordPress cards
+    --wp-card-bg: #ffffff;
+    --wp-card-border: var(--wp-border-width) solid var(--wp-border-color);
+    --wp-card-border-radius: var(--wp-border-radius);
+    --wp-card-shadow: var(--wp-shadow);
+    --wp-card-padding: var(--wp-spacing-lg);
+    // WordPress transitions
+    --wp-transition: 0.15s ease-in-out;
+    --wp-transition-slow: 0.3s ease-in-out;
+    // WordPress z-index scale
+    --wp-z-dropdown: 1000;
+    --wp-z-sticky: 1020;
+    --wp-z-fixed: 1030;
+    --wp-z-modal-backdrop: 1040;
+    --wp-z-modal: 1050;
+    --wp-z-popover: 1060;
+    --wp-z-tooltip: 1070;
+}
+
+// ==========================================================================
+// PLUGIN-SPECIFIC VARIABLES
+// ==========================================================================
+:root {
+    // Plugin branding colors (subtle, professional)
+    --ecowitt-primary: var(--wp-color-primary);
+    --ecowitt-primary-hover: var(--wp-color-primary-hover);
+    --ecowitt-accent: var(--wp-color-info);
+    // Connection status colors
+    --ecowitt-status-connected: var(--wp-color-success);
+    --ecowitt-status-disconnected: var(--wp-color-gray-400);
+    --ecowitt-status-error: var(--wp-color-danger);
+    --ecowitt-status-warning: var(--wp-color-warning);
+    // Component-specific variables
+    --ecowitt-card-bg: var(--wp-color-white);
+    --ecowitt-card-border: var(--wp-border-color);
+    --ecowitt-card-shadow: var(--wp-shadow);
+    --ecowitt-card-radius: var(--wp-border-radius-lg);
+    // Form field sizing
+    --ecowitt-field-height-sm: 30px;
+    --ecowitt-field-height: 32px;
+    --ecowitt-field-height-lg: 40px;
+    // Animation timing
+    --ecowitt-animation-fast: 0.15s;
+    --ecowitt-animation-normal: 0.25s;
+    --ecowitt-animation-slow: 0.35s;
+}
+
+// ==========================================================================
+// BREAKPOINTS
+// ==========================================================================
+$breakpoints: ( 'xs': 480px, 'sm': 640px, 'md': 768px, 'lg': 1024px, 'xl': 1280px, 'xxl': 1536px);
+// ==========================================================================
+// COMPONENT DEFAULTS
+// ==========================================================================
+// Button defaults
+$button-padding-x: var(--wp-spacing-md);
+$button-padding-y: var(--wp-spacing-sm);
+$button-border-radius: var(--wp-border-radius);
+$button-font-weight: var(--wp-font-weight-medium);
+// Card defaults
+$card-padding: var(--wp-spacing-lg);
+$card-border-radius: var(--ecowitt-card-radius);
+$card-border: var(--wp-border-width) solid var(--ecowitt-card-border);
+$card-shadow: var(--ecowitt-card-shadow);
+// Form defaults
+$form-field-padding-x: var(--wp-spacing-sm);
+$form-field-padding-y: var(--wp-spacing-xs);
+$form-field-border: var(--wp-border-width) solid var(--wp-border-color);
+$form-field-border-radius: var(--wp-border-radius);
+$form-field-font-size: var(--wp-font-size-base);
+// Grid defaults
+$grid-columns: 12;
+$grid-gutter: var(--wp-spacing-md);
+$container-max-width: 1200px;

--- a/assets/src/scss/admin.scss
+++ b/assets/src/scss/admin.scss
@@ -1,0 +1,48 @@
+/**
+ * Ecowitt Weather Block - Admin Styles
+ * 
+ * A modern, professional admin interface that respects WordPress
+ * admin design patterns while providing a clean, extensible foundation.
+ * 
+ * @package EcowittWeatherBlock
+ * @since 1.0.0
+ */
+
+// ==========================================================================
+// FOUNDATION
+// ==========================================================================
+// Core abstracts - order matters
+@import 'abstracts/functions';
+@import 'abstracts/variables';
+@import 'abstracts/mixins';
+// ==========================================================================
+// VENDOR & BASE
+// ==========================================================================
+// WordPress admin compatibility
+@import 'base/wordpress-admin';
+@import 'base/reset';
+@import 'base/typography';
+// ==========================================================================
+// LAYOUT SYSTEMS
+// ==========================================================================
+@import 'layout/grid';
+@import 'layout/containers';
+@import 'layout/spacing';
+@import 'layout/admin-page';
+// ==========================================================================
+// PAGES
+// ==========================================================================
+@import 'pages/settings';
+// ==========================================================================
+// UTILITIES
+// ==========================================================================
+@import 'utilities/display';
+@import 'utilities/flexbox';
+// ==========================================================================
+// COMPONENTS
+// ==========================================================================
+// Base components
+@import 'components/admin-header';
+@import 'components/buttons';
+@import 'components/forms';
+@import 'components/connections';

--- a/assets/src/scss/base/_typography.scss
+++ b/assets/src/scss/base/_typography.scss
@@ -1,0 +1,222 @@
+/**
+ * Typography
+ * 
+ * Typography styles that complement WordPress admin interface.
+ */
+
+.ecowitt-admin {
+    // ==========================================================================
+    // HEADINGS
+    // ==========================================================================
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        font-family: var(--wp-font-family);
+        font-weight: var(--wp-font-weight-semibold);
+        line-height: var(--wp-line-height-tight);
+        color: var(--wp-color-gray-800);
+        margin-bottom: var(--wp-spacing-sm);
+    }
+    h1 {
+        font-size: var(--wp-font-size-xxl);
+        margin-bottom: var(--wp-spacing-lg);
+    }
+    h2 {
+        font-size: var(--wp-font-size-xl);
+        margin-bottom: var(--wp-spacing-md);
+    }
+    h3 {
+        font-size: var(--wp-font-size-lg);
+        margin-bottom: var(--wp-spacing-md);
+    }
+    h4 {
+        font-size: var(--wp-font-size-md);
+        margin-bottom: var(--wp-spacing-sm);
+    }
+    h5,
+    h6 {
+        font-size: var(--wp-font-size-base);
+        margin-bottom: var(--wp-spacing-sm);
+    }
+    // ==========================================================================
+    // BODY TEXT
+    // ==========================================================================
+    p {
+        margin-bottom: var(--wp-spacing-md);
+        line-height: var(--wp-line-height-relaxed);
+        &:last-child {
+            margin-bottom: 0;
+        }
+        &.lead {
+            font-size: var(--wp-font-size-md);
+            font-weight: var(--wp-font-weight-normal);
+            color: var(--wp-color-gray-600);
+        }
+        &.small {
+            font-size: var(--wp-font-size-sm);
+            color: var(--wp-color-gray-500);
+        }
+    }
+    // ==========================================================================
+    // LINKS
+    // ==========================================================================
+    a {
+        color: var(--wp-color-primary);
+        text-decoration: none;
+        transition: color var(--wp-transition);
+        &:hover {
+            color: var(--wp-color-primary-hover);
+            text-decoration: underline;
+        }
+        @include focus-visible {
+            outline: 2px solid var(--wp-color-primary);
+            outline-offset: 2px;
+            border-radius: var(--wp-border-radius-sm);
+        }
+    }
+    // ==========================================================================
+    // LISTS
+    // ==========================================================================
+    ul,
+    ol {
+        margin-bottom: var(--wp-spacing-md);
+        padding-left: var(--wp-spacing-lg);
+        li {
+            margin-bottom: var(--wp-spacing-xs);
+        }
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+    dl {
+        margin-bottom: var(--wp-spacing-md);
+        dt {
+            font-weight: var(--wp-font-weight-semibold);
+            margin-bottom: var(--wp-spacing-xs);
+        }
+        dd {
+            margin-bottom: var(--wp-spacing-sm);
+            margin-left: var(--wp-spacing-md);
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+    // ==========================================================================
+    // INLINE ELEMENTS
+    // ==========================================================================
+    strong,
+    b {
+        font-weight: var(--wp-font-weight-bold);
+    }
+    em,
+    i {
+        font-style: italic;
+    }
+    code {
+        font-family: var(--wp-font-family-mono);
+        font-size: 0.875em;
+        background-color: var(--wp-color-gray-100);
+        color: var(--wp-color-gray-800);
+        padding: 0.125em 0.25em;
+        border-radius: var(--wp-border-radius-sm);
+    }
+    pre {
+        font-family: var(--wp-font-family-mono);
+        font-size: var(--wp-font-size-sm);
+        background-color: var(--wp-color-gray-100);
+        color: var(--wp-color-gray-800);
+        padding: var(--wp-spacing-md);
+        border-radius: var(--wp-border-radius);
+        overflow-x: auto;
+        margin-bottom: var(--wp-spacing-md);
+        code {
+            background: none;
+            padding: 0;
+        }
+    }
+    // ==========================================================================
+    // UTILITY CLASSES
+    // ==========================================================================
+    .text-xs {
+        font-size: var(--wp-font-size-xs);
+    }
+    .text-sm {
+        font-size: var(--wp-font-size-sm);
+    }
+    .text-base {
+        font-size: var(--wp-font-size-base);
+    }
+    .text-md {
+        font-size: var(--wp-font-size-md);
+    }
+    .text-lg {
+        font-size: var(--wp-font-size-lg);
+    }
+    .text-xl {
+        font-size: var(--wp-font-size-xl);
+    }
+    .text-xxl {
+        font-size: var(--wp-font-size-xxl);
+    }
+    .font-normal {
+        font-weight: var(--wp-font-weight-normal);
+    }
+    .font-medium {
+        font-weight: var(--wp-font-weight-medium);
+    }
+    .font-semibold {
+        font-weight: var(--wp-font-weight-semibold);
+    }
+    .font-bold {
+        font-weight: var(--wp-font-weight-bold);
+    }
+    .leading-tight {
+        line-height: var(--wp-line-height-tight);
+    }
+    .leading-normal {
+        line-height: var(--wp-line-height-normal);
+    }
+    .leading-relaxed {
+        line-height: var(--wp-line-height-relaxed);
+    }
+    .text-left {
+        text-align: left;
+    }
+    .text-center {
+        text-align: center;
+    }
+    .text-right {
+        text-align: right;
+    }
+    .text-primary {
+        color: var(--wp-color-primary);
+    }
+    .text-success {
+        color: var(--wp-color-success);
+    }
+    .text-warning {
+        color: var(--wp-color-warning);
+    }
+    .text-danger {
+        color: var(--wp-color-danger);
+    }
+    .text-info {
+        color: var(--wp-color-info);
+    }
+    .text-muted {
+        color: var(--wp-color-gray-500);
+    }
+    .truncate {
+        @include truncate;
+    }
+    .line-clamp-2 {
+        @include line-clamp(2);
+    }
+    .line-clamp-3 {
+        @include line-clamp(3);
+    }
+}

--- a/assets/src/scss/base/_wordpress-admin.scss
+++ b/assets/src/scss/base/_wordpress-admin.scss
@@ -1,0 +1,150 @@
+/**
+ * WordPress Admin Integration
+ * 
+ * Ensures our styles work harmoniously with WordPress admin styles
+ * and respect user preferences.
+ */
+
+// ==========================================================================
+// WORDPRESS ADMIN CONTEXT
+// ==========================================================================
+// Ensure our styles only apply within our admin context
+.ecowitt-admin {
+    // Reset any potential conflicts with WP admin styles
+    box-sizing: border-box;
+    *,
+    *::before,
+    *::after {
+        box-sizing: inherit;
+    }
+    // Use WordPress admin font stack
+    font-family: var(--wp-font-family);
+    font-size: var(--wp-font-size-base);
+    line-height: var(--wp-line-height-normal);
+    color: var(--wp-color-gray-800);
+    // Ensure proper text rendering
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+}
+
+// ==========================================================================
+// WORDPRESS ADMIN OVERRIDES
+// ==========================================================================
+// Ensure our content doesn't interfere with WP admin layout
+.ecowitt-admin {
+    // Remove any inherited margins that might break layout
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        margin-top: 0;
+    }
+    // Ensure proper spacing for WordPress admin context
+    .wrap & {
+        margin-top: var(--wp-spacing-md);
+    }
+}
+
+// ==========================================================================
+// WORDPRESS FORM COMPATIBILITY
+// ==========================================================================
+// Ensure our forms work with WordPress admin form styles
+.ecowitt-admin {
+    // Reset WordPress form table styles within our components
+    .form-table {
+        // Keep WordPress form table styles where appropriate
+        border-collapse: collapse;
+        margin-top: var(--wp-spacing-md);
+        width: 100%;
+        th {
+            font-weight: var(--wp-font-weight-semibold);
+            text-align: left;
+            padding: var(--wp-spacing-lg) var(--wp-spacing-sm) var(--wp-spacing-lg) 0;
+            width: 200px;
+            vertical-align: top;
+        }
+        td {
+            padding: var(--wp-spacing-md) 0;
+            vertical-align: top;
+        }
+    }
+    // WordPress notice compatibility
+    .notice {
+        background: var(--wp-color-white);
+        border-left: 4px solid var(--wp-color-primary);
+        padding: var(--wp-spacing-md);
+        margin: var(--wp-spacing-md) 0;
+        box-shadow: var(--wp-shadow-sm);
+        &.notice-success {
+            border-left-color: var(--wp-color-success);
+        }
+        &.notice-warning {
+            border-left-color: var(--wp-color-warning);
+        }
+        &.notice-error {
+            border-left-color: var(--wp-color-danger);
+        }
+        &.notice-info {
+            border-left-color: var(--wp-color-info);
+        }
+    }
+}
+
+// ==========================================================================
+// ACCESSIBILITY ENHANCEMENTS
+// ==========================================================================
+// Respect user preferences
+.ecowitt-admin {
+    @include reduced-motion {
+        *,
+        *::before,
+        *::after {
+            animation-duration: 0.01ms !important;
+            animation-iteration-count: 1 !important;
+            transition-duration: 0.01ms !important;
+        }
+    }
+    @include high-contrast {
+        // Enhanced contrast for high contrast mode
+        --wp-border-color: var(--wp-color-gray-600);
+        --ecowitt-card-border: var(--wp-color-gray-600);
+    }
+}
+
+// ==========================================================================
+// ADMIN COLOR SCHEME SUPPORT
+// ==========================================================================
+// Support for WordPress admin color schemes
+// These will automatically use the user's selected admin color scheme
+.ecowitt-admin {
+    // Primary actions should use the admin color scheme
+    .button-primary,
+    .btn--primary {
+        background-color: var(--wp-color-primary);
+        border-color: var(--wp-color-primary);
+        &:hover {
+            background-color: var(--wp-color-primary-hover);
+            border-color: var(--wp-color-primary-hover);
+        }
+        &:focus {
+            background-color: var(--wp-color-primary-focus);
+            border-color: var(--wp-color-primary-focus);
+            box-shadow: 0 0 0 1px var(--wp-color-primary-focus);
+        }
+    }
+    // Links should use admin color scheme
+    a:not(.button):not(.btn) {
+        color: var(--wp-color-primary);
+        &:hover {
+            color: var(--wp-color-primary-hover);
+        }
+        &:focus {
+            color: var(--wp-color-primary-focus);
+            outline: 2px solid var(--wp-color-primary-focus);
+            outline-offset: 2px;
+        }
+    }
+}

--- a/assets/src/scss/components/_admin-header.scss
+++ b/assets/src/scss/components/_admin-header.scss
@@ -1,0 +1,25 @@
+/**
+ * Admin Page Header Component
+ * 
+ * Reusable header styles for admin pages.
+ */
+
+.ecowitt-admin {
+    &__header {
+        padding-bottom: var(--wp-spacing-sm);
+    }
+    &__title {
+        margin: 0 0 var(--wp-spacing-xs) 0;
+        font-size: 23px;
+        font-weight: 600;
+        color: var(--wp-color-gray-900);
+    }
+    &__description {
+        margin: 0;
+        font-size: var(--wp-font-size-base);
+        color: var(--wp-color-gray-600);
+    }
+    &__content {
+        max-width: none;
+    }
+}

--- a/assets/src/scss/components/_buttons.scss
+++ b/assets/src/scss/components/_buttons.scss
@@ -1,0 +1,464 @@
+/**
+ * Button Components - Clean Weather Station UI
+ * 
+ * Modern, clean button system for weather data interfaces.
+ */
+
+// ==========================================================================
+// BASE BUTTON - CLEAN FOUNDATION
+// ==========================================================================
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 10px 20px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    line-height: 1.5;
+    border: 1px solid #d1d5db;
+    border-radius: 8px;
+    cursor: pointer;
+    text-decoration: none;
+    transition: all 0.15s ease-in-out;
+    background: #ffffff;
+    color: #374151;
+    outline: none;
+    &:focus {
+        outline: none;
+        border-color: #3b82f6;
+        box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    }
+    &:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        pointer-events: none;
+    }
+    &--small {
+        padding: 6px 12px;
+        font-size: 0.75rem;
+    }
+    &--large {
+        padding: 12px 24px;
+        font-size: 1rem;
+    }
+    &--block {
+        display: flex;
+        width: 100%;
+    }
+}
+
+// ==========================================================================
+// PRIMARY BUTTON - WEATHER BLUE
+// ==========================================================================
+.btn--primary {
+    background: #0ea5e9;
+    color: white;
+    border-color: #0ea5e9;
+    &:hover:not(:disabled) {
+        background: #0284c7;
+        border-color: #0284c7;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 8px rgba(14, 165, 233, 0.3);
+    }
+    &:active {
+        transform: translateY(0);
+    }
+}
+
+.btn--primary-outline {
+    background: transparent;
+    color: #0ea5e9;
+    border-color: #0ea5e9;
+    &:hover:not(:disabled) {
+        background: #0ea5e9;
+        color: white;
+    }
+}
+
+// ==========================================================================
+// SECONDARY BUTTON - NEUTRAL GRAY
+// ==========================================================================
+.btn--secondary {
+    background: #f8fafc;
+    color: #475569;
+    border-color: #e2e8f0;
+    &:hover:not(:disabled) {
+        background: #f1f5f9;
+        border-color: #cbd5e1;
+        transform: translateY(-1px);
+    }
+}
+
+// ==========================================================================
+// SUCCESS BUTTON - NATURE GREEN
+// ==========================================================================
+.btn--success {
+    background: #22c55e;
+    color: white;
+    border-color: #22c55e;
+    &:hover:not(:disabled) {
+        background: #16a34a;
+        border-color: #16a34a;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 8px rgba(34, 197, 94, 0.3);
+    }
+}
+
+.btn--success-outline {
+    background: transparent;
+    color: #22c55e;
+    border-color: #22c55e;
+    &:hover:not(:disabled) {
+        background: #22c55e;
+        color: white;
+    }
+}
+
+// ==========================================================================
+// WARNING BUTTON - WEATHER ALERT
+// ==========================================================================
+.btn--warning {
+    background: #f59e0b;
+    color: white;
+    border-color: #f59e0b;
+    &:hover:not(:disabled) {
+        background: #d97706;
+        border-color: #d97706;
+        transform: translateY(-1px);
+        box-shadow: 0 4px 8px rgba(245, 158, 11, 0.3);
+    }
+}
+
+.btn--warning-outline {
+    background: transparent;
+    color: #f59e0b;
+    border-color: #f59e0b;
+    &:hover:not(:disabled) {
+        background: #f59e0b;
+        color: white;
+    }
+}
+
+// ==========================================================================
+// DANGER BUTTON - ERROR/DISCONNECT
+// ==========================================================================
+
+/**
+ * Buttons
+ * 
+ * Modern button components that integrate with WordPress admin styles.
+ */
+
+.ecowitt-admin {
+    // ==========================================================================
+    // BASE BUTTON
+    // ==========================================================================
+    .btn {
+        @include button-base;
+        // Remove WordPress button styles when using our class
+        &.button {
+            height: auto;
+            padding: $button-padding-y $button-padding-x;
+            font-size: var(--wp-font-size-base);
+        }
+        // Icon spacing
+        .icon {
+            flex-shrink: 0;
+            &:first-child {
+                margin-right: var(--wp-spacing-xs);
+            }
+            &:last-child {
+                margin-left: var(--wp-spacing-xs);
+            }
+            &:only-child {
+                margin: 0;
+            }
+        }
+        // Loading state
+        &--loading {
+            position: relative;
+            color: transparent;
+            &::after {
+                content: '';
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                width: 16px;
+                height: 16px;
+                margin: -8px 0 0 -8px;
+                border: 2px solid currentColor;
+                border-top-color: transparent;
+                border-radius: 50%;
+                animation: btn-spin 0.8s linear infinite;
+            }
+        }
+    }
+    @keyframes btn-spin {
+        to {
+            transform: rotate(360deg);
+        }
+    }
+    // ==========================================================================
+    // BUTTON VARIANTS
+    // ==========================================================================
+    // Primary button (uses WordPress admin color)
+    .btn--primary {
+        @include button-variant( var(--wp-color-primary), var(--wp-color-white), var(--wp-color-primary), var(--wp-color-primary-hover), var(--wp-color-white));
+    }
+    // Secondary button
+    .btn--secondary {
+        @include button-variant( var(--wp-color-gray-100), var(--wp-color-gray-700), var(--wp-border-color), var(--wp-color-gray-200), var(--wp-color-gray-800));
+    }
+    // Success button
+    .btn--success {
+        @include button-variant( var(--wp-color-success), var(--wp-color-white), var(--wp-color-success), var(--wp-color-success-hover), var(--wp-color-white));
+    }
+    // Danger button
+    .btn--danger {
+        @include button-variant( var(--wp-color-danger), var(--wp-color-white), var(--wp-color-danger), var(--wp-color-danger-hover), var(--wp-color-white));
+    }
+    // Warning button
+    .btn--warning {
+        @include button-variant( var(--wp-color-warning), var(--wp-color-gray-800), var(--wp-color-warning), var(--wp-color-warning-hover), var(--wp-color-gray-800));
+    }
+    // Info button
+    .btn--info {
+        @include button-variant( var(--wp-color-info), var(--wp-color-white), var(--wp-color-info), var(--wp-color-info-hover), var(--wp-color-white));
+    }
+    // Ghost/outline variants
+    .btn--outline {
+        background-color: transparent;
+        &.btn--primary {
+            color: var(--wp-color-primary);
+            border-color: var(--wp-color-primary);
+            &:hover:not(:disabled) {
+                background-color: var(--wp-color-primary);
+                color: var(--wp-color-white);
+            }
+        }
+        &.btn--secondary {
+            color: var(--wp-color-gray-600);
+            border-color: var(--wp-border-color);
+            &:hover:not(:disabled) {
+                background-color: var(--wp-color-gray-100);
+                color: var(--wp-color-gray-700);
+            }
+        }
+        &.btn--success {
+            color: var(--wp-color-success);
+            border-color: var(--wp-color-success);
+            &:hover:not(:disabled) {
+                background-color: var(--wp-color-success);
+                color: var(--wp-color-white);
+            }
+        }
+        &.btn--danger {
+            color: var(--wp-color-danger);
+            border-color: var(--wp-color-danger);
+            &:hover:not(:disabled) {
+                background-color: var(--wp-color-danger);
+                color: var(--wp-color-white);
+            }
+        }
+        &.btn--warning {
+            color: var(--wp-color-warning);
+            border-color: var(--wp-color-warning);
+            &:hover:not(:disabled) {
+                background-color: var(--wp-color-warning);
+                color: var(--wp-color-gray-800);
+            }
+        }
+        &.btn--info {
+            color: var(--wp-color-info);
+            border-color: var(--wp-color-info);
+            &:hover:not(:disabled) {
+                background-color: var(--wp-color-info);
+                color: var(--wp-color-white);
+            }
+        }
+    }
+    // Ghost button (no border)
+    .btn--ghost {
+        background-color: transparent;
+        border-color: transparent;
+        &:hover:not(:disabled) {
+            background-color: var(--wp-color-gray-100);
+        }
+    }
+    // ==========================================================================
+    // BUTTON SIZES
+    // ==========================================================================
+    .btn--xs {
+        padding: calc(var(--wp-spacing-xs) * 0.5) var(--wp-spacing-xs);
+        font-size: var(--wp-font-size-xs);
+        border-radius: var(--wp-border-radius-sm);
+    }
+    .btn--sm {
+        padding: var(--wp-spacing-xs) var(--wp-spacing-sm);
+        font-size: var(--wp-font-size-sm);
+    }
+    .btn--lg {
+        padding: var(--wp-spacing-sm) var(--wp-spacing-lg);
+        font-size: var(--wp-font-size-md);
+        border-radius: var(--wp-border-radius-lg);
+    }
+    .btn--xl {
+        padding: var(--wp-spacing-md) var(--wp-spacing-xl);
+        font-size: var(--wp-font-size-lg);
+        border-radius: var(--wp-border-radius-lg);
+    }
+    // ==========================================================================
+    // BUTTON LAYOUTS
+    // ==========================================================================
+    .btn--block {
+        display: flex;
+        width: 100%;
+    }
+    .btn--icon-only {
+        padding: $button-padding-y;
+        width: calc(#{$button-padding-y} * 2 + 1.2em);
+        &.btn--sm {
+            padding: var(--wp-spacing-xs);
+            width: calc(var(--wp-spacing-xs) * 2 + 1em);
+        }
+        &.btn--lg {
+            padding: var(--wp-spacing-sm);
+            width: calc(var(--wp-spacing-sm) * 2 + 1.5em);
+        }
+    }
+    // ==========================================================================
+    // BUTTON GROUPS
+    // ==========================================================================
+    .btn-group {
+        display: inline-flex;
+        vertical-align: middle;
+        .btn {
+            position: relative;
+            z-index: 1;
+            &:not(:first-child) {
+                margin-left: -1px;
+                border-top-left-radius: 0;
+                border-bottom-left-radius: 0;
+            }
+            &:not(:last-child) {
+                border-top-right-radius: 0;
+                border-bottom-right-radius: 0;
+            }
+            &:hover,
+            &:focus,
+            &:active {
+                z-index: 2;
+            }
+        }
+        &--vertical {
+            flex-direction: column;
+            .btn {
+                &:not(:first-child) {
+                    margin-left: 0;
+                    margin-top: -1px;
+                    border-top-left-radius: 0;
+                    border-top-right-radius: 0;
+                    border-bottom-left-radius: var(--wp-border-radius);
+                }
+                &:not(:last-child) {
+                    border-bottom-left-radius: 0;
+                    border-bottom-right-radius: 0;
+                    border-top-right-radius: var(--wp-border-radius);
+                }
+            }
+        }
+    }
+}
+
+.btn--danger-outline {
+    background: transparent;
+    color: #ef4444;
+    border-color: #ef4444;
+    &:hover:not(:disabled) {
+        background: #ef4444;
+        color: white;
+    }
+}
+
+// ==========================================================================
+// GHOST BUTTON - MINIMAL
+// ==========================================================================
+.btn--ghost {
+    background: transparent;
+    color: #6b7280;
+    border-color: transparent;
+    &:hover:not(:disabled) {
+        background: #f9fafb;
+        color: #374151;
+    }
+}
+
+// ==========================================================================
+// LINK BUTTON - TEXT STYLE
+// ==========================================================================
+.btn--link {
+    background: transparent;
+    color: #0ea5e9;
+    border-color: transparent;
+    padding: 4px 8px;
+    text-decoration: none;
+    &:hover:not(:disabled) {
+        color: #0284c7;
+        text-decoration: underline;
+        text-underline-offset: 2px;
+    }
+}
+
+// ==========================================================================
+// BUTTON GROUPS
+// ==========================================================================
+.btn-group {
+    display: inline-flex;
+    .btn {
+        border-radius: 0;
+        border-right-width: 0;
+        &:first-child {
+            border-radius: 8px 0 0 8px;
+        }
+        &:last-child {
+            border-radius: 0 8px 8px 0;
+            border-right-width: 1px;
+        }
+        &:only-child {
+            border-radius: 8px;
+            border-right-width: 1px;
+        }
+    }
+}
+
+// ==========================================================================
+// LOADING STATE
+// ==========================================================================
+.btn--loading {
+    position: relative;
+    color: transparent;
+    pointer-events: none;
+    &::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 16px;
+        height: 16px;
+        border: 2px solid transparent;
+        border-top: 2px solid currentColor;
+        border-radius: 50%;
+        animation: spin 1s linear infinite;
+    }
+}
+
+@keyframes spin {
+    from {
+        transform: translate(-50%, -50%) rotate(0deg);
+    }
+    to {
+        transform: translate(-50%, -50%) rotate(360deg);
+    }
+}

--- a/assets/src/scss/components/_connections.scss
+++ b/assets/src/scss/components/_connections.scss
@@ -1,0 +1,282 @@
+/**
+ * Connection Components
+ * 
+ * Styles for weather station connection cards and related components.
+ */
+
+.ecowitt-admin {
+    // ==========================================================================
+    // CONNECTIONS CONTAINER
+    // ==========================================================================
+    .connections-container {
+        margin-bottom: var(--wp-spacing-xl);
+    }
+    .connections-list {
+        display: grid;
+        gap: var(--wp-spacing-lg);
+        margin-bottom: var(--wp-spacing-xl);
+        @include breakpoint('lg') {
+            grid-template-columns: repeat(auto-fit, minmax(250px, 400px));
+        }
+    }
+    // ==========================================================================
+    // CONNECTION CARD
+    // ==========================================================================
+    .connection-card {
+        @include card;
+        position: relative;
+        transition: all var(--wp-transition);
+        &:hover {
+            box-shadow: var(--wp-shadow-md);
+            transform: translateY(-1px);
+        }
+        // Connection status variants
+        &.connection--active {
+            border-left: 4px solid var(--ecowitt-status-connected);
+            .connection__status {
+                color: var(--ecowitt-status-connected);
+                background-color: color-mix(in srgb, var(--ecowitt-status-connected) 10%, transparent);
+            }
+        }
+        &.connection--inactive {
+            border-left: 4px solid var(--ecowitt-status-disconnected);
+            .connection__status {
+                color: var(--ecowitt-status-disconnected);
+                background-color: color-mix(in srgb, var(--ecowitt-status-disconnected) 10%, transparent);
+            }
+        }
+        &.connection--error {
+            border-left: 4px solid var(--ecowitt-status-error);
+            .connection__status {
+                color: var(--ecowitt-status-error);
+                background-color: color-mix(in srgb, var(--ecowitt-status-error) 10%, transparent);
+            }
+        }
+    }
+    // ==========================================================================
+    // CONNECTION HEADER
+    // ==========================================================================
+    .connection__header {
+        @include flex-between;
+        margin-bottom: var(--wp-spacing-md);
+        padding-bottom: var(--wp-spacing-sm);
+        border-bottom: var(--wp-border-width) solid var(--wp-color-gray-200);
+    }
+    .connection__title-group {
+        min-width: 0; // Allow truncation
+        flex: 1;
+    }
+    .connection__title {
+        margin: 0 0 var(--wp-spacing-xs) 0;
+        font-size: var(--wp-font-size-lg);
+        font-weight: var(--wp-font-weight-semibold);
+        color: var(--wp-color-gray-800);
+        @include truncate;
+    }
+    .connection__status {
+        display: inline-flex;
+        align-items: center;
+        padding: var(--wp-spacing-xs) var(--wp-spacing-sm);
+        border-radius: var(--wp-border-radius-xl);
+        font-size: var(--wp-font-size-xs);
+        font-weight: var(--wp-font-weight-medium);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        &::before {
+            content: '';
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background-color: currentColor;
+            margin-right: var(--wp-spacing-xs);
+        }
+    }
+    .connection__actions {
+        display: flex;
+        gap: var(--wp-spacing-xs);
+        margin-left: var(--wp-spacing-md);
+    }
+    // ==========================================================================
+    // CONNECTION CONTENT
+    // ==========================================================================
+    .connection__content {
+        .connection__info {
+            display: grid;
+            gap: var(--wp-spacing-sm);
+            margin-bottom: var(--wp-spacing-md);
+        }
+        .connection__field {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: var(--wp-spacing-xs) 0;
+            &:not(:last-child) {
+                border-bottom: var(--wp-border-width) solid var(--wp-color-gray-100);
+            }
+        }
+        .connection__field-label {
+            font-size: var(--wp-font-size-sm);
+            font-weight: var(--wp-font-weight-medium);
+            color: var(--wp-color-gray-600);
+        }
+        .connection__field-value {
+            font-size: var(--wp-font-size-sm);
+            color: var(--wp-color-gray-800);
+            font-family: var(--wp-font-family-mono);
+            @include truncate;
+            max-width: 60%;
+        }
+    }
+    // ==========================================================================
+    // CONNECTION FORM (Edit/Add)
+    // ==========================================================================
+    .connection__form {
+        margin-top: var(--wp-spacing-md);
+        padding-top: var(--wp-spacing-md);
+        border-top: var(--wp-border-width) solid var(--wp-color-gray-200);
+        .form-grid {
+            display: grid;
+            gap: var(--wp-spacing-md);
+            @include breakpoint('md') {
+                grid-template-columns: repeat(2, 1fr);
+            }
+        }
+        .form-group {
+            &--full {
+                @include breakpoint('md') {
+                    grid-column: 1 / -1;
+                }
+            }
+        }
+        .form-actions {
+            display: flex;
+            gap: var(--wp-spacing-sm);
+            justify-content: flex-end;
+            margin-top: var(--wp-spacing-lg);
+            padding-top: var(--wp-spacing-md);
+            border-top: var(--wp-border-width) solid var(--wp-color-gray-200);
+        }
+    }
+    // ==========================================================================
+    // EMPTY STATE
+    // ==========================================================================
+    .connections-empty {
+        text-align: center;
+        padding: var(--wp-spacing-xxl) var(--wp-spacing-lg);
+        background: var(--wp-color-gray-50);
+        border: 2px dashed var(--wp-color-gray-300);
+        border-radius: var(--wp-border-radius-lg);
+        margin-bottom: var(--wp-spacing-xl);
+        .empty-icon {
+            margin: 0 auto var(--wp-spacing-lg);
+            width: 64px;
+            height: 64px;
+            color: var(--wp-color-gray-400);
+            svg {
+                width: 100%;
+                height: 100%;
+            }
+        }
+        .empty-title {
+            margin: 0 0 var(--wp-spacing-sm) 0;
+            font-size: var(--wp-font-size-xl);
+            font-weight: var(--wp-font-weight-semibold);
+            color: var(--wp-color-gray-700);
+        }
+        .empty-description {
+            margin: 0;
+            font-size: var(--wp-font-size-md);
+            color: var(--wp-color-gray-500);
+            max-width: 400px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+    }
+    // ==========================================================================
+    // NEW CONNECTION SECTION
+    // ==========================================================================
+    .new-connection {
+        @include card;
+        text-align: center;
+        padding: var(--wp-spacing-xl);
+        border: 2px dashed var(--wp-color-gray-300);
+        background: var(--wp-color-gray-50);
+        transition: all var(--wp-transition);
+        &:hover {
+            border-color: var(--wp-color-primary);
+            background: color-mix(in srgb, var(--wp-color-primary) 3%, var(--wp-color-gray-50));
+        }
+        &__icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 48px;
+            height: 48px;
+            margin: 0 auto var(--wp-spacing-md);
+            background: var(--wp-color-white);
+            border: 2px solid var(--wp-color-gray-300);
+            border-radius: 50%;
+            color: var(--wp-color-gray-500);
+            transition: all var(--wp-transition);
+        }
+        &:hover &__icon {
+            border-color: var(--wp-color-primary);
+            color: var(--wp-color-primary);
+        }
+        &__title {
+            margin: 0 0 var(--wp-spacing-sm) 0;
+            font-size: var(--wp-font-size-lg);
+            font-weight: var(--wp-font-weight-semibold);
+            color: var(--wp-color-gray-800);
+        }
+        &__description {
+            margin: 0 0 var(--wp-spacing-lg) 0;
+            font-size: var(--wp-font-size-base);
+            color: var(--wp-color-gray-600);
+            max-width: 400px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+    }
+    // ==========================================================================
+    // NEW CONNECTION FORM
+    // ==========================================================================
+    .new-connection-form {
+        @include card;
+        margin-top: var(--wp-spacing-lg);
+        display: none;
+        &.is-active {
+            display: block;
+            animation: slideIn 0.3s ease-out;
+        }
+        .form-header {
+            padding-bottom: var(--wp-spacing-lg);
+            margin-bottom: var(--wp-spacing-lg);
+            border-bottom: var(--wp-border-width) solid var(--wp-color-gray-200);
+        }
+        .form-title {
+            margin: 0 0 var(--wp-spacing-sm) 0;
+            font-size: var(--wp-font-size-xl);
+            font-weight: var(--wp-font-weight-semibold);
+            color: var(--wp-color-gray-800);
+        }
+        .form-description {
+            margin: 0;
+            font-size: var(--wp-font-size-base);
+            color: var(--wp-color-gray-600);
+        }
+    }
+    // ==========================================================================
+    // SETTINGS SECTIONS
+    // ==========================================================================
+    @keyframes slideIn {
+        from {
+            opacity: 0;
+            transform: translateY(-10px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+}

--- a/assets/src/scss/components/_connections_clean.scss
+++ b/assets/src/scss/components/_connections_clean.scss
@@ -1,0 +1,279 @@
+/**
+ * Connection Components
+ * 
+ * Styles for weather station connection cards and related components.
+ */
+
+.ecowitt-admin {
+    // ==========================================================================
+    // CONNECTIONS CONTAINER
+    // ==========================================================================
+    .connections-container {
+        margin-bottom: var(--wp-spacing-xl);
+    }
+    .connections-list {
+        display: grid;
+        gap: var(--wp-spacing-lg);
+        margin-bottom: var(--wp-spacing-xl);
+        @include breakpoint('lg') {
+            grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+        }
+    }
+    // ==========================================================================
+    // CONNECTION CARD
+    // ==========================================================================
+    .connection-card {
+        @include card;
+        position: relative;
+        transition: all var(--wp-transition);
+        &:hover {
+            box-shadow: var(--wp-shadow-md);
+            transform: translateY(-1px);
+        }
+        // Connection status variants
+        &.connection--active {
+            border-left: 4px solid var(--ecowitt-status-connected);
+            .connection__status {
+                color: var(--ecowitt-status-connected);
+                background-color: color-mix(in srgb, var(--ecowitt-status-connected) 10%, transparent);
+            }
+        }
+        &.connection--inactive {
+            border-left: 4px solid var(--ecowitt-status-disconnected);
+            .connection__status {
+                color: var(--ecowitt-status-disconnected);
+                background-color: color-mix(in srgb, var(--ecowitt-status-disconnected) 10%, transparent);
+            }
+        }
+        &.connection--error {
+            border-left: 4px solid var(--ecowitt-status-error);
+            .connection__status {
+                color: var(--ecowitt-status-error);
+                background-color: color-mix(in srgb, var(--ecowitt-status-error) 10%, transparent);
+            }
+        }
+    }
+    // ==========================================================================
+    // CONNECTION HEADER
+    // ==========================================================================
+    .connection__header {
+        @include flex-between;
+        margin-bottom: var(--wp-spacing-md);
+        padding-bottom: var(--wp-spacing-sm);
+        border-bottom: var(--wp-border-width) solid var(--wp-color-gray-200);
+    }
+    .connection__title-group {
+        min-width: 0; // Allow truncation
+        flex: 1;
+    }
+    .connection__title {
+        margin: 0 0 var(--wp-spacing-xs) 0;
+        font-size: var(--wp-font-size-lg);
+        font-weight: var(--wp-font-weight-semibold);
+        color: var(--wp-color-gray-800);
+        @include truncate;
+    }
+    .connection__status {
+        display: inline-flex;
+        align-items: center;
+        padding: var(--wp-spacing-xs) var(--wp-spacing-sm);
+        border-radius: var(--wp-border-radius-xl);
+        font-size: var(--wp-font-size-xs);
+        font-weight: var(--wp-font-weight-medium);
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        &::before {
+            content: '';
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background-color: currentColor;
+            margin-right: var(--wp-spacing-xs);
+        }
+    }
+    .connection__actions {
+        display: flex;
+        gap: var(--wp-spacing-xs);
+        margin-left: var(--wp-spacing-md);
+    }
+    // ==========================================================================
+    // CONNECTION CONTENT
+    // ==========================================================================
+    .connection__content {
+        .connection__info {
+            display: grid;
+            gap: var(--wp-spacing-sm);
+            margin-bottom: var(--wp-spacing-md);
+        }
+        .connection__field {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: var(--wp-spacing-xs) 0;
+            &:not(:last-child) {
+                border-bottom: var(--wp-border-width) solid var(--wp-color-gray-100);
+            }
+        }
+        .connection__field-label {
+            font-size: var(--wp-font-size-sm);
+            font-weight: var(--wp-font-weight-medium);
+            color: var(--wp-color-gray-600);
+        }
+        .connection__field-value {
+            font-size: var(--wp-font-size-sm);
+            color: var(--wp-color-gray-800);
+            font-family: var(--wp-font-family-mono);
+            @include truncate;
+            max-width: 60%;
+        }
+    }
+    // ==========================================================================
+    // CONNECTION FORM (Edit/Add)
+    // ==========================================================================
+    .connection__form {
+        margin-top: var(--wp-spacing-md);
+        padding-top: var(--wp-spacing-md);
+        border-top: var(--wp-border-width) solid var(--wp-color-gray-200);
+        .form-grid {
+            display: grid;
+            gap: var(--wp-spacing-md);
+            @include breakpoint('md') {
+                grid-template-columns: repeat(2, 1fr);
+            }
+        }
+        .form-group {
+            &--full {
+                @include breakpoint('md') {
+                    grid-column: 1 / -1;
+                }
+            }
+        }
+        .form-actions {
+            display: flex;
+            gap: var(--wp-spacing-sm);
+            justify-content: flex-end;
+            margin-top: var(--wp-spacing-lg);
+            padding-top: var(--wp-spacing-md);
+            border-top: var(--wp-border-width) solid var(--wp-color-gray-200);
+        }
+    }
+    // ==========================================================================
+    // EMPTY STATE
+    // ==========================================================================
+    .connections-empty {
+        text-align: center;
+        padding: var(--wp-spacing-xxl) var(--wp-spacing-lg);
+        background: var(--wp-color-gray-50);
+        border: 2px dashed var(--wp-color-gray-300);
+        border-radius: var(--wp-border-radius-lg);
+        margin-bottom: var(--wp-spacing-xl);
+        .empty-icon {
+            margin: 0 auto var(--wp-spacing-lg);
+            width: 64px;
+            height: 64px;
+            color: var(--wp-color-gray-400);
+            svg {
+                width: 100%;
+                height: 100%;
+            }
+        }
+        .empty-title {
+            margin: 0 0 var(--wp-spacing-sm) 0;
+            font-size: var(--wp-font-size-xl);
+            font-weight: var(--wp-font-weight-semibold);
+            color: var(--wp-color-gray-700);
+        }
+        .empty-description {
+            margin: 0;
+            font-size: var(--wp-font-size-md);
+            color: var(--wp-color-gray-500);
+            max-width: 400px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+    }
+    // ==========================================================================
+    // NEW CONNECTION SECTION
+    // ==========================================================================
+    .new-connection {
+        @include card;
+        text-align: center;
+        padding: var(--wp-spacing-xl);
+        border: 2px dashed var(--wp-color-gray-300);
+        background: var(--wp-color-gray-50);
+        transition: all var(--wp-transition);
+        &:hover {
+            border-color: var(--wp-color-primary);
+            background: color-mix(in srgb, var(--wp-color-primary) 3%, var(--wp-color-gray-50));
+        }
+        &__icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 48px;
+            height: 48px;
+            margin: 0 auto var(--wp-spacing-md);
+            background: var(--wp-color-white);
+            border: 2px solid var(--wp-color-gray-300);
+            border-radius: 50%;
+            color: var(--wp-color-gray-500);
+            transition: all var(--wp-transition);
+        }
+        &:hover &__icon {
+            border-color: var(--wp-color-primary);
+            color: var(--wp-color-primary);
+        }
+        &__title {
+            margin: 0 0 var(--wp-spacing-sm) 0;
+            font-size: var(--wp-font-size-lg);
+            font-weight: var(--wp-font-weight-semibold);
+            color: var(--wp-color-gray-800);
+        }
+        &__description {
+            margin: 0 0 var(--wp-spacing-lg) 0;
+            font-size: var(--wp-font-size-base);
+            color: var(--wp-color-gray-600);
+            max-width: 400px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+    }
+    // ==========================================================================
+    // NEW CONNECTION FORM
+    // ==========================================================================
+    .new-connection-form {
+        @include card;
+        margin-top: var(--wp-spacing-lg);
+        display: none;
+        &.is-active {
+            display: block;
+            animation: slideIn 0.3s ease-out;
+        }
+        .form-header {
+            padding-bottom: var(--wp-spacing-lg);
+            margin-bottom: var(--wp-spacing-lg);
+            border-bottom: var(--wp-border-width) solid var(--wp-color-gray-200);
+        }
+        .form-title {
+            margin: 0 0 var(--wp-spacing-sm) 0;
+            font-size: var(--wp-font-size-xl);
+            font-weight: var(--wp-font-weight-semibold);
+            color: var(--wp-color-gray-800);
+        }
+        .form-description {
+            margin: 0;
+            font-size: var(--wp-font-size-base);
+            color: var(--wp-color-gray-600);
+        }
+    }
+    @keyframes slideIn {
+        from {
+            opacity: 0;
+            transform: translateY(-10px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+}

--- a/assets/src/scss/components/_connections_old.scss
+++ b/assets/src/scss/components/_connections_old.scss
@@ -1,0 +1,310 @@
+    /**
+ * Connections Component - SLEEK & PROFESSIONAL EDITION 🖤
+ * 
+ * Modern, minimalist design with sophisticated colors and clean animations.
+ */
+
+// ==========================================================================
+// CONNECTIONS CONTAINER - CLEAN & MODERN
+// ==========================================================================
+.ecowitt-admin {
+    .connections-container {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: $spacing-xl;
+        background: #ffffff;
+        border: 1px solid #e5e7eb;
+        border-radius: 12px;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+    }
+    .connections-list {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+        gap: $spacing-lg;
+        margin-bottom: $spacing-xl;
+    }
+    // ==========================================================================
+    // CONNECTION CARD - SOPHISTICATED CARDS
+    // ==========================================================================
+    .connection-card {
+        background: #ffffff;
+        border: 1px solid #e5e7eb;
+        border-radius: 8px;
+        padding: $spacing-lg;
+        transition: all 0.2s ease;
+        position: relative;
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 3px;
+            border-radius: 8px 8px 0 0;
+            background: #6b7280;
+        }
+        &:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+            border-color: #d1d5db;
+        }
+        &.connection--active {
+            &::before {
+                background: #10b981;
+            }
+            .connection__status {
+                background: #d1fae5;
+                color: #047857;
+                border: 1px solid #a7f3d0;
+            }
+        }
+        &.connection--inactive {
+            &::before {
+                background: #f59e0b;
+            }
+            .connection__status {
+                background: #fef3c7;
+                color: #92400e;
+                border: 1px solid #fde68a;
+            }
+        }
+        &.connection--editing {
+            border-color: #3b82f6;
+            box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+            &::before {
+                background: #3b82f6;
+            }
+        }
+    }
+    .connection__header {
+        display: flex;
+        justify-content: space-between;
+        align-items: flex-start;
+        margin-bottom: $spacing-md;
+        gap: $spacing-md;
+    }
+    .connection__title-group {
+        flex: 1;
+    }
+    .connection__title {
+        margin: 0 0 $spacing-xs 0;
+        color: #111827;
+        font-size: 1.25rem;
+        font-weight: 600;
+        line-height: 1.4;
+    }
+    .connection__status {
+        display: inline-flex;
+        align-items: center;
+        padding: 4px 12px;
+        font-size: 0.75rem;
+        font-weight: 500;
+        border-radius: 20px;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+    .connection__actions {
+        display: flex;
+        gap: $spacing-xs;
+    }
+    .connection__content {
+        margin-bottom: $spacing-md;
+        .connection__description {
+            margin: 0 0 $spacing-md 0;
+            color: #6b7280;
+            font-style: italic;
+            padding: $spacing-sm;
+            background: #f9fafb;
+            border-radius: 6px;
+            border-left: 3px solid #e5e7eb;
+        }
+    }
+    .connection__details {
+        display: grid;
+        gap: $spacing-sm;
+    }
+    .connection__detail {
+        display: flex;
+        align-items: center;
+        gap: $spacing-sm;
+        padding: $spacing-xs;
+        .detail__label {
+            min-width: 100px;
+            font-weight: 500;
+            color: #374151;
+            font-size: 0.875rem;
+        }
+        .detail__value {
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            background: #f3f4f6;
+            color: #1f2937;
+            padding: 4px 8px;
+            border-radius: 4px;
+            font-size: 0.875rem;
+            border: 1px solid #e5e7eb;
+            &--masked {
+                background: #fee2e2;
+                color: #991b1b;
+                border-color: #fecaca;
+            }
+        }
+    }
+    .connection__footer {
+        margin-top: $spacing-md;
+        padding-top: $spacing-md;
+        border-top: 1px solid #f3f4f6;
+        .connection__meta {
+            font-size: 0.875rem;
+            color: #6b7280;
+        }
+    }
+    // ==========================================================================
+    // NEW CONNECTION SECTION - CLEAN CALL-TO-ACTION
+    // ==========================================================================
+    .new-connection {
+        text-align: center;
+        padding: $spacing-xl;
+        border: 2px dashed #d1d5db;
+        border-radius: 8px;
+        background: #fafafa;
+        transition: all 0.2s ease;
+        &:hover {
+            border-color: #3b82f6;
+            background: #f8faff;
+        }
+        .new-connection__icon {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 48px;
+            height: 48px;
+            background: #3b82f6;
+            border-radius: 8px;
+            margin-bottom: $spacing-md;
+            svg {
+                color: white;
+            }
+        }
+        .new-connection__title {
+            margin: 0 0 $spacing-sm 0;
+            color: #111827;
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        .new-connection__description {
+            margin: 0 0 $spacing-lg 0;
+            color: #6b7280;
+            max-width: 400px;
+            margin-left: auto;
+            margin-right: auto;
+        }
+    }
+    .new-connection-form {
+        margin-top: $spacing-lg;
+        padding: $spacing-xl;
+        background: #ffffff;
+        border: 1px solid #e5e7eb;
+        border-radius: 8px;
+        &.is-active {
+            animation: slideDown 0.3s ease;
+        }
+        .form-header {
+            margin-bottom: $spacing-lg;
+            text-align: center;
+            .form-title {
+                margin: 0 0 $spacing-sm 0;
+                color: #111827;
+                font-size: 1.5rem;
+                font-weight: 600;
+            }
+            .form-description {
+                margin: 0;
+                color: #6b7280;
+            }
+        }
+    }
+    // ==========================================================================
+    // EMPTY STATE - ELEGANT PLACEHOLDER
+    // ==========================================================================
+    .connections-empty {
+        text-align: center;
+        padding: $spacing-xxl;
+        color: #6b7280;
+        .empty-icon {
+            margin-bottom: $spacing-lg;
+            opacity: 0.5;
+            svg {
+                color: #9ca3af;
+            }
+        }
+        .empty-title {
+            margin: 0 0 $spacing-sm 0;
+            color: #374151;
+            font-size: 1.25rem;
+            font-weight: 600;
+        }
+        .empty-description {
+            margin: 0;
+            max-width: 400px;
+            margin: 0 auto;
+            line-height: 1.6;
+        }
+    }
+    @keyframes slideDown {
+        from {
+            opacity: 0;
+            transform: translateY(-10px);
+        }
+        to {
+            opacity: 1;
+            transform: translateY(0);
+        }
+    }
+}
+
+// CONNECTIONS CONTAINER - MAGICAL GRADIENT PARADISE
+// ==========================================================================
+.ecowitt-admin {
+    .connections-container {
+        position: relative;
+        padding: $spacing-xxl;
+        margin-bottom: $spacing-xl;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%);
+        border-radius: 24px;
+        box-shadow: 0 25px 50px rgba(102, 126, 234, 0.3);
+        overflow: hidden;
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(10px);
+            z-index: 0;
+        }
+        >* {
+            position: relative;
+            z-index: 1;
+        }
+        &::after {
+            content: '🌤️⛈️🌈';
+            position: absolute;
+            top: $spacing-lg;
+            right: $spacing-lg;
+            font-size: 2rem;
+            opacity: 0.7;
+            animation: weather-float 4s ease-in-out infinite;
+            z-index: 1;
+        }
+    }
+    .connections-list {
+        display: grid;
+        gap: $spacing-xl;
+        margin-bottom: $spacing-xxl;
+        @include tablet-up {
+            grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+        }
+    }
+    background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);

--- a/assets/src/scss/components/_forms.scss
+++ b/assets/src/scss/components/_forms.scss
@@ -1,0 +1,782 @@
+/**
+ * Form Components - Clean Weather Station UI
+ * 
+ * Professional form styling for weather data configuration.
+ */
+
+// ==========================================================================
+// FORM LAYOUTS
+// ==========================================================================
+.form-group {
+    margin-bottom: 1.5rem;
+}
+
+.form-row {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    .form-group {
+        flex: 1;
+        margin-bottom: 0;
+    }
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+// ==========================================================================
+// LABELS
+// ==========================================================================
+.form-label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+    color: #374151;
+    font-size: 0.875rem;
+}
+
+.form-label--required {
+    &::after {
+        content: ' *';
+        color: #ef4444;
+    }
+}
+
+// ==========================================================================
+// INPUT FIELDS
+// ==========================================================================
+.form-input {
+    display: block;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    color: #374151;
+    background: #ffffff;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+    &:focus {
+        outline: none;
+        border-color: #3b82f6;
+        box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    }
+    &:disabled {
+        background-color: #f9fafb;
+        opacity: 0.6;
+        cursor: not-allowed;
+    }
+    &::placeholder {
+        color: #9ca3af;
+    }
+}
+
+.form-input--small {
+    padding: 0.5rem 0.75rem;
+    font-size: 0.75rem;
+}
+
+.form-input--large {
+    padding: 1rem 1.25rem;
+    font-size: 1rem;
+}
+
+// ==========================================================================
+// INPUT STATES
+// ==========================================================================
+.form-input--success {
+    border-color: #22c55e;
+    &:focus {
+        border-color: #22c55e;
+        box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.1);
+    }
+}
+
+.form-input--error {
+    border-color: #ef4444;
+    &:focus {
+        border-color: #ef4444;
+        box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);
+    }
+}
+
+.form-input--warning {
+    border-color: #f59e0b;
+    &:focus {
+        border-color: #f59e0b;
+        box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.1);
+    }
+}
+
+// ==========================================================================
+// TEXTAREA
+// ==========================================================================
+.form-textarea {
+    @extend .form-input;
+    resize: vertical;
+    min-height: 100px;
+}
+
+// ==========================================================================
+// SELECT
+// ==========================================================================
+.form-select {
+    @extend .form-input;
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3E%3C/svg%3E");
+    background-position: right 0.5rem center;
+    background-repeat: no-repeat;
+    background-size: 1.5em 1.5em;
+    padding-right: 2.5rem;
+    appearance: none;
+}
+
+// ==========================================================================
+// CHECKBOX & RADIO
+// ==========================================================================
+.form-checkbox,
+.form-radio {
+    appearance: none;
+    width: 1rem;
+    height: 1rem;
+    border: 1px solid #d1d5db;
+    background: #ffffff;
+    transition: all 0.15s ease-in-out;
+    &:focus {
+        outline: none;
+        border-color: #3b82f6;
+        box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+    }
+    &:checked {
+        border-color: #3b82f6;
+        background-color: #3b82f6;
+    }
+}
+
+.form-checkbox {
+    border-radius: 0.25rem;
+    &:checked {
+        background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12.207 4.793a1 1 0 0 1 0 1.414l-5 5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.5 9.086l4.293-4.293a1 1 0 0 1 1.414 0z'/%3E%3C/svg%3E");
+    }
+}
+
+.form-radio {
+    border-radius: 50%;
+    &:checked {
+        background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='3'/%3E%3C/svg%3E");
+    }
+}
+
+// ==========================================================================
+// CHECKBOX & RADIO LABELS
+// ==========================================================================
+.form-check {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    .form-check-input {
+        flex-shrink: 0;
+    }
+    .form-check-label {
+        margin-bottom: 0;
+        font-weight: 400;
+        cursor: pointer;
+    }
+}
+
+// ==========================================================================
+// HELP TEXT
+// ==========================================================================
+.form-help {
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    color: #6b7280;
+    line-height: 1.4;
+}
+
+.form-help--success {
+    color: #22c55e;
+}
+
+.form-help--error {
+    color: #ef4444;
+}
+
+.form-help--warning {
+    color: #f59e0b;
+}
+
+// ==========================================================================
+// INPUT GROUPS
+// ==========================================================================
+.input-group {
+    display: flex;
+    .form-input {
+        border-radius: 0;
+        &:first-child {
+            border-radius: 6px 0 0 6px;
+        }
+        &:last-child {
+            border-radius: 0 6px 6px 0;
+            border-left-width: 0;
+        }
+        &:only-child {
+            border-radius: 6px;
+        }
+        &:not(:first-child):not(:last-child) {
+            border-left-width: 0;
+            border-right-width: 0;
+        }
+    }
+}
+
+.input-group-text {
+    display: flex;
+    align-items: center;
+    padding: 0.75rem 1rem;
+    font-size: 0.875rem;
+    font-weight: 400;
+    line-height: 1.5;
+    color: #6b7280;
+    text-align: center;
+    white-space: nowrap;
+    background-color: #f9fafb;
+    border: 1px solid #d1d5db;
+    &:first-child {
+        border-radius: 6px 0 0 6px;
+        border-right: 0;
+    }
+    &:last-child {
+        border-radius: 0 6px 6px 0;
+        border-left: 0;
+    }
+}
+
+// ==========================================================================
+// FORM VALIDATION
+// ==========================================================================
+.form-error {
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    color: #ef4444;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    &::before {
+        content: '⚠';
+        font-size: 0.875rem;
+    }
+}
+
+.form-success {
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    color: #22c55e;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    &::before {
+        content: '✓';
+        font-size: 0.875rem;
+    }
+}
+
+// ==========================================================================
+// FIELDSETS
+// ==========================================================================
+.form-fieldset {
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 1.5rem;
+    .form-legend {
+        font-weight: 600;
+        color: #374151;
+        font-size: 1rem;
+        margin-bottom: 1rem;
+        padding: 0 0.5rem;
+        background: #ffffff;
+    }
+}
+
+// ==========================================================================
+// FORM SECTIONS
+// ==========================================================================
+.form-section {
+    margin-bottom: 2rem;
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+.form-section-header {
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px solid #e5e7eb;
+    .form-section-title {
+        margin: 0 0 0.25rem 0;
+        font-size: 1.125rem;
+        font-weight: 600;
+        color: #111827;
+    }
+    .form-section-description {
+        margin: 0;
+        font-size: 0.875rem;
+        color: #6b7280;
+        line-height: 1.5;
+    }
+}
+
+// FORM FOUNDATIONS - GORGEOUS BASICS! 🌟
+// ==========================================================================
+.ecowitt-admin {
+    .form-group {
+        position: relative;
+        margin-bottom: var(--wp-spacing-lg);
+        &.form-group--floating {
+            .form-control {
+                padding-top: 20px;
+                padding-bottom: 8px;
+                &:focus~.form-label,
+                &:not(:placeholder-shown)~.form-label {
+                    transform: translateY(-12px) scale(0.85);
+                    color: #667eea;
+                }
+            }
+            .form-label {
+                position: absolute;
+                top: 16px;
+                left: 16px;
+                transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+                pointer-events: none;
+                z-index: 2;
+                background: white;
+                padding: 0 4px;
+                margin: 0;
+            }
+        }
+    }
+    // ==========================================================================
+    // LABELS - BEAUTIFUL TYPOGRAPHY! 📝
+    // ==========================================================================
+    .form-label {
+        display: block;
+        margin-bottom: 8px;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: #334155;
+        position: relative;
+        // Required indicator with style!
+        &.form-label--required::after {
+            content: '*';
+            color: #ef4444;
+            margin-left: 4px;
+            font-size: 1.1rem;
+            animation: required-pulse 2s infinite;
+        }
+        // Optional indicator
+        &.form-label--optional::after {
+            content: '(optional)';
+            color: #64748b;
+            margin-left: 6px;
+            font-size: 0.8rem;
+            font-weight: 400;
+            font-style: italic;
+        }
+        // Icon support
+        &.form-label--icon {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            svg {
+                width: 16px;
+                height: 16px;
+                color: #667eea;
+            }
+        }
+    }
+    // ==========================================================================
+    // FORM CONTROLS - STUNNING INPUTS! 🎯
+    // ==========================================================================
+    .form-control {
+        width: 100%;
+        padding: 14px 16px;
+        font-size: 0.95rem;
+        line-height: 1.5;
+        color: #1e293b;
+        background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+        border: 2px solid #e2e8f0;
+        border-radius: 12px;
+        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        position: relative;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+        &::placeholder {
+            color: #94a3b8;
+            transition: opacity 0.3s ease;
+        }
+        &:hover {
+            border-color: #cbd5e1;
+            background: linear-gradient(135deg, #ffffff 0%, #f1f5f9 100%);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+        &:focus {
+            outline: none;
+            border-color: #667eea;
+            background: white;
+            box-shadow: 0 0 0 4px rgba(102, 126, 234, 0.1), 0 8px 20px rgba(102, 126, 234, 0.15);
+            transform: scale(1.02);
+            &::placeholder {
+                opacity: 0.7;
+            }
+        }
+        // Input states with vibrant colors!
+        &.form-control--success {
+            border-color: #10b981;
+            background: linear-gradient(135deg, #ffffff 0%, #f0fdf4 100%);
+            &:focus {
+                border-color: #059669;
+                box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.15), 0 8px 20px rgba(16, 185, 129, 0.2);
+            }
+        }
+        &.form-control--error {
+            border-color: #ef4444;
+            background: linear-gradient(135deg, #ffffff 0%, #fef2f2 100%);
+            animation: shake 0.5s ease-in-out;
+            &:focus {
+                border-color: #dc2626;
+                box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.15), 0 8px 20px rgba(239, 68, 68, 0.2);
+            }
+        }
+        &.form-control--warning {
+            border-color: #f59e0b;
+            background: linear-gradient(135deg, #ffffff 0%, #fffbeb 100%);
+            &:focus {
+                border-color: #d97706;
+                box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.15), 0 8px 20px rgba(245, 158, 11, 0.2);
+            }
+        }
+        // Special input types
+        &[type="password"] {
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            letter-spacing: 2px;
+        }
+        &[type="email"] {
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+        }
+    }
+    // ==========================================================================
+    // TEXTAREAS - EXPANDABLE BEAUTY! 📝
+    // ==========================================================================
+    textarea.form-control {
+        min-height: 120px;
+        resize: vertical;
+        padding: 16px;
+        line-height: 1.6;
+        &:focus {
+            transform: none; // Don't scale textareas
+        }
+    }
+    // ==========================================================================
+    // SELECT DROPDOWNS - STYLISH CHOICES! 🎨
+    // ==========================================================================
+    .form-select {
+        @extend .form-control;
+        cursor: pointer;
+        background-image: linear-gradient(45deg, transparent 50%, #667eea 50%), linear-gradient(135deg, #667eea 50%, transparent 50%);
+        background-position: calc(100% - 20px) calc(1em + 2px), calc(100% - 15px) calc(1em + 2px);
+        background-size: 5px 5px, 5px 5px;
+        background-repeat: no-repeat;
+        padding-right: 45px;
+        &:hover {
+            background-image: linear-gradient(45deg, transparent 50%, #5a6fd8 50%), linear-gradient(135deg, #5a6fd8 50%, transparent 50%);
+        }
+        &:focus {
+            background-image: linear-gradient(45deg, transparent 50%, #4e5bc6 50%), linear-gradient(135deg, #4e5bc6 50%, transparent 50%);
+        }
+    }
+    // ==========================================================================
+    // FORM GRID - ORGANIZED LAYOUTS! 📐
+    // ==========================================================================
+    .form-grid {
+        display: grid;
+        gap: var(--wp-spacing-lg);
+        &.form-grid--2-col {
+            @include breakpoint('md') {
+                grid-template-columns: repeat(2, 1fr);
+            }
+        }
+        &.form-grid--3-col {
+            @include breakpoint('md') {
+                grid-template-columns: repeat(2, 1fr);
+            }
+            @include breakpoint('lg') {
+                grid-template-columns: repeat(3, 1fr);
+            }
+        }
+        &.form-grid--auto {
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        }
+        // Responsive single column override
+        &.form-grid--single {
+            grid-template-columns: 1fr;
+        }
+    }
+    // ==========================================================================
+    // FORM HELP TEXT - HELPFUL GUIDANCE! 💡
+    // ==========================================================================
+    .form-help {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+        margin-top: 8px;
+        font-size: 0.85rem;
+        line-height: 1.5;
+        color: #64748b;
+        padding: 8px 12px;
+        background: rgba(102, 126, 234, 0.05);
+        border-radius: 8px;
+        border-left: 3px solid #667eea;
+        &::before {
+            content: 'ℹ️';
+            font-size: 0.9rem;
+            margin-top: 2px;
+            flex-shrink: 0;
+        }
+        &.form-help--success {
+            color: #047857;
+            background: rgba(16, 185, 129, 0.05);
+            border-left-color: #10b981;
+            &::before {
+                content: '✅';
+            }
+        }
+        &.form-help--error {
+            color: #b91c1c;
+            background: rgba(239, 68, 68, 0.05);
+            border-left-color: #ef4444;
+            &::before {
+                content: '❌';
+            }
+        }
+        &.form-help--warning {
+            color: #92400e;
+            background: rgba(245, 158, 11, 0.05);
+            border-left-color: #f59e0b;
+            &::before {
+                content: '⚠️';
+            }
+        }
+    }
+    // ==========================================================================
+    // FORM ACTIONS - ORGANIZED BUTTONS! 🎯
+    // ==========================================================================
+    .form-actions {
+        display: flex;
+        align-items: center;
+        gap: var(--wp-spacing-md);
+        margin-top: var(--wp-spacing-xl);
+        padding-top: var(--wp-spacing-lg);
+        border-top: 2px dashed rgba(102, 126, 234, 0.2);
+        position: relative;
+        &::before {
+            content: '';
+            position: absolute;
+            top: -1px;
+            left: 0;
+            right: 0;
+            height: 2px;
+            background: linear-gradient(90deg, transparent, #667eea, transparent);
+            opacity: 0.3;
+        }
+        .ml-auto {
+            margin-left: auto;
+        }
+        @include breakpoint('sm',
+        'max') {
+            flex-direction: column;
+            .btn {
+                width: 100%;
+            }
+            .ml-auto {
+                margin-left: 0;
+                order: -1;
+            }
+        }
+    }
+    // ==========================================================================
+    // INPUT GROUPS - COMBINED CONTROLS! 🔗
+    // ==========================================================================
+    .input-group {
+        display: flex;
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+        .form-control {
+            border-radius: 0;
+            border-right: none;
+            box-shadow: none;
+            &:focus {
+                transform: none;
+                z-index: 2;
+                position: relative;
+            }
+            &:first-child {
+                border-radius: 12px 0 0 12px;
+            }
+            &:last-child {
+                border-radius: 0 12px 12px 0;
+                border-right: 2px solid #e2e8f0;
+            }
+        }
+        .input-group-text {
+            display: flex;
+            align-items: center;
+            padding: 14px 16px;
+            background: linear-gradient(135deg, #f8fafc, #e2e8f0);
+            border: 2px solid #e2e8f0;
+            border-right: none;
+            color: #64748b;
+            font-weight: 500;
+            &:last-child {
+                border-right: 2px solid #e2e8f0;
+                border-left: none;
+            }
+            svg {
+                width: 16px;
+                height: 16px;
+                color: #667eea;
+            }
+        }
+    }
+    // ==========================================================================
+    // CHECKBOXES & RADIOS - BEAUTIFUL CHOICES! ✨
+    // ==========================================================================
+    .form-check {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        margin-bottom: var(--wp-spacing-md);
+        padding: 12px;
+        border-radius: 12px;
+        transition: all 0.3s ease;
+        &:hover {
+            background: rgba(102, 126, 234, 0.05);
+        }
+        .form-check-input {
+            margin: 0;
+            width: 20px;
+            height: 20px;
+            border: 2px solid #cbd5e1;
+            border-radius: 6px;
+            background: white;
+            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            position: relative;
+            cursor: pointer;
+            &:checked {
+                background: linear-gradient(135deg, #667eea, #764ba2);
+                border-color: #667eea;
+                &::after {
+                    content: '✓';
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    transform: translate(-50%, -50%);
+                    color: white;
+                    font-size: 12px;
+                    font-weight: bold;
+                }
+            }
+            &:focus {
+                outline: none;
+                box-shadow: 0 0 0 4px rgba(102, 126, 234, 0.2);
+            }
+            &[type="radio"] {
+                border-radius: 50%;
+                &:checked::after {
+                    content: '';
+                    width: 8px;
+                    height: 8px;
+                    background: white;
+                    border-radius: 50%;
+                }
+            }
+        }
+        .form-check-label {
+            flex: 1;
+            cursor: pointer;
+            line-height: 1.5;
+            color: #334155;
+            font-weight: 500;
+        }
+    }
+    // ==========================================================================
+    // STUNNING ANIMATIONS! 🎬
+    // ==========================================================================
+    @keyframes required-pulse {
+        0%,
+        100% {
+            opacity: 1;
+            transform: scale(1);
+        }
+        50% {
+            opacity: 0.7;
+            transform: scale(1.1);
+        }
+    }
+    @keyframes shake {
+        0%,
+        100% {
+            transform: translateX(0);
+        }
+        25% {
+            transform: translateX(-4px);
+        }
+        75% {
+            transform: translateX(4px);
+        }
+    }
+    // ==========================================================================
+    // LOADING OVERLAYS! ⚡
+    // ==========================================================================
+    .form-loading {
+        position: relative;
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(255, 255, 255, 0.8);
+            backdrop-filter: blur(2px);
+            z-index: 10;
+            border-radius: inherit;
+        }
+        &::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 32px;
+            height: 32px;
+            margin: -16px 0 0 -16px;
+            border: 3px solid #e2e8f0;
+            border-top: 3px solid #667eea;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            z-index: 11;
+        }
+    }
+    @keyframes spin {
+        from {
+            transform: rotate(0deg);
+        }
+        to {
+            transform: rotate(360deg);
+        }
+    }
+}

--- a/assets/src/scss/layout/_admin-page.scss
+++ b/assets/src/scss/layout/_admin-page.scss
@@ -1,0 +1,10 @@
+/**
+ * Admin Page Layout
+ * 
+ * Base layout styles for all admin pages.
+ */
+
+.ecowitt-admin {
+    background: #ffffff;
+    padding: var(--wp-spacing-lg);
+}

--- a/assets/src/scss/layout/_containers.scss
+++ b/assets/src/scss/layout/_containers.scss
@@ -1,0 +1,141 @@
+/**
+ * Containers
+ * 
+ * Container components for layout structure.
+ */
+
+@use 'sass:map';
+.ecowitt-admin {
+    // ==========================================================================
+    // MAIN CONTAINERS
+    // ==========================================================================
+    .container {
+        @include container;
+        &--sm {
+            max-width: map.get($breakpoints, 'sm');
+        }
+        &--md {
+            max-width: map.get($breakpoints, 'md');
+        }
+        &--lg {
+            max-width: map.get($breakpoints, 'lg');
+        }
+        &--xl {
+            max-width: map.get($breakpoints, 'xl');
+        }
+        &--fluid {
+            max-width: none;
+        }
+    }
+    // ==========================================================================
+    // SECTIONS
+    // ==========================================================================
+    .section {
+        padding: var(--wp-spacing-xl) 0;
+        &--sm {
+            padding: var(--wp-spacing-lg) 0;
+        }
+        &--lg {
+            padding: var(--wp-spacing-xxl) 0;
+        }
+        &--no-padding {
+            padding: 0;
+        }
+        &--no-padding-top {
+            padding-top: 0;
+        }
+        &--no-padding-bottom {
+            padding-bottom: 0;
+        }
+    }
+    // ==========================================================================
+    // PANELS
+    // ==========================================================================
+    .panel {
+        background: var(--wp-color-white);
+        border: var(--wp-border-width) solid var(--wp-border-color);
+        border-radius: var(--wp-border-radius-lg);
+        box-shadow: var(--wp-shadow-sm);
+        &__header {
+            padding: var(--wp-spacing-lg);
+            border-bottom: var(--wp-border-width) solid var(--wp-border-color);
+            background: var(--wp-color-gray-50);
+            border-radius: var(--wp-border-radius-lg) var(--wp-border-radius-lg) 0 0;
+            &:last-child {
+                border-bottom: none;
+                border-radius: var(--wp-border-radius-lg);
+            }
+        }
+        &__body {
+            padding: var(--wp-spacing-lg);
+        }
+        &__footer {
+            padding: var(--wp-spacing-lg);
+            border-top: var(--wp-border-width) solid var(--wp-border-color);
+            background: var(--wp-color-gray-50);
+            border-radius: 0 0 var(--wp-border-radius-lg) var(--wp-border-radius-lg);
+            &:first-child {
+                border-top: none;
+                border-radius: var(--wp-border-radius-lg);
+            }
+        }
+        // Panel variants
+        &--bordered {
+            border: 2px solid var(--wp-border-color);
+        }
+        &--elevated {
+            box-shadow: var(--wp-shadow-lg);
+        }
+        &--flush {
+            border: none;
+            box-shadow: none;
+            .panel__header,
+            .panel__footer {
+                background: transparent;
+            }
+        }
+    }
+    // ==========================================================================
+    // CONTENT AREAS
+    // ==========================================================================
+    .content {
+        &--centered {
+            text-align: center;
+        }
+        &--padded {
+            padding: var(--wp-spacing-lg);
+        }
+        &--padded-sm {
+            padding: var(--wp-spacing-md);
+        }
+        &--padded-lg {
+            padding: var(--wp-spacing-xl);
+        }
+    }
+    // ==========================================================================
+    // SIDEBAR LAYOUTS
+    // ==========================================================================
+    .sidebar-layout {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: var(--wp-spacing-lg);
+        @include breakpoint('lg') {
+            grid-template-columns: 1fr 300px;
+            &--reverse {
+                grid-template-columns: 300px 1fr;
+            }
+            &--wide {
+                grid-template-columns: 1fr 400px;
+                &.sidebar-layout--reverse {
+                    grid-template-columns: 400px 1fr;
+                }
+            }
+        }
+    }
+    .sidebar-layout__main {
+        min-width: 0; // Prevent overflow
+    }
+    .sidebar-layout__sidebar {
+        min-width: 0; // Prevent overflow
+    }
+}

--- a/assets/src/scss/layout/_grid.scss
+++ b/assets/src/scss/layout/_grid.scss
@@ -1,0 +1,244 @@
+/**
+ * Grid System
+ * 
+ * A flexible 12-column grid system for WordPress admin layouts.
+ */
+
+.ecowitt-admin {
+    // ==========================================================================
+    // GRID CONTAINER
+    // ==========================================================================
+    .grid {
+        display: grid;
+        gap: $grid-gutter;
+        // Auto-fit columns with minimum width
+        &--auto {
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        }
+        // Specific column counts
+        &--1 {
+            grid-template-columns: 1fr;
+        }
+        &--2 {
+            grid-template-columns: repeat(2, 1fr);
+        }
+        &--3 {
+            grid-template-columns: repeat(3, 1fr);
+        }
+        &--4 {
+            grid-template-columns: repeat(4, 1fr);
+        }
+        &--6 {
+            grid-template-columns: repeat(6, 1fr);
+        }
+        &--12 {
+            grid-template-columns: repeat(12, 1fr);
+        }
+        // Responsive grid variants
+        @include breakpoint('md') {
+            &--md-2 {
+                grid-template-columns: repeat(2, 1fr);
+            }
+            &--md-3 {
+                grid-template-columns: repeat(3, 1fr);
+            }
+            &--md-4 {
+                grid-template-columns: repeat(4, 1fr);
+            }
+        }
+        @include breakpoint('lg') {
+            &--lg-2 {
+                grid-template-columns: repeat(2, 1fr);
+            }
+            &--lg-3 {
+                grid-template-columns: repeat(3, 1fr);
+            }
+            &--lg-4 {
+                grid-template-columns: repeat(4, 1fr);
+            }
+            &--lg-6 {
+                grid-template-columns: repeat(6, 1fr);
+            }
+        }
+        // Gap variants
+        &--gap-sm {
+            gap: var(--wp-spacing-sm);
+        }
+        &--gap-md {
+            gap: var(--wp-spacing-md);
+        }
+        &--gap-lg {
+            gap: var(--wp-spacing-lg);
+        }
+        &--gap-xl {
+            gap: var(--wp-spacing-xl);
+        }
+    }
+    // ==========================================================================
+    // GRID ITEMS
+    // ==========================================================================
+    .grid-item {
+        // Column spanning
+        &--span-2 {
+            grid-column: span 2;
+        }
+        &--span-3 {
+            grid-column: span 3;
+        }
+        &--span-4 {
+            grid-column: span 4;
+        }
+        &--span-6 {
+            grid-column: span 6;
+        }
+        &--span-full {
+            grid-column: 1 / -1;
+        }
+        // Row spanning
+        &--row-span-2 {
+            grid-row: span 2;
+        }
+        &--row-span-3 {
+            grid-row: span 3;
+        }
+        // Responsive spanning
+        @include breakpoint('md') {
+            &--md-span-2 {
+                grid-column: span 2;
+            }
+            &--md-span-3 {
+                grid-column: span 3;
+            }
+            &--md-span-4 {
+                grid-column: span 4;
+            }
+            &--md-span-6 {
+                grid-column: span 6;
+            }
+            &--md-span-full {
+                grid-column: 1 / -1;
+            }
+        }
+        @include breakpoint('lg') {
+            &--lg-span-2 {
+                grid-column: span 2;
+            }
+            &--lg-span-3 {
+                grid-column: span 3;
+            }
+            &--lg-span-4 {
+                grid-column: span 4;
+            }
+            &--lg-span-6 {
+                grid-column: span 6;
+            }
+            &--lg-span-full {
+                grid-column: 1 / -1;
+            }
+        }
+    }
+    // ==========================================================================
+    // FLEXBOX GRID (Alternative)
+    // ==========================================================================
+    .flex-grid {
+        display: flex;
+        flex-wrap: wrap;
+        margin: calc(#{$grid-gutter} / -2);
+        &--nowrap {
+            flex-wrap: nowrap;
+        }
+        &--gap-sm {
+            margin: calc(var(--wp-spacing-sm) / -2);
+            >* {
+                padding: calc(var(--wp-spacing-sm) / 2);
+            }
+        }
+        &--gap-lg {
+            margin: calc(var(--wp-spacing-lg) / -2);
+            >* {
+                padding: calc(var(--wp-spacing-lg) / 2);
+            }
+        }
+    }
+    .flex-grid>* {
+        padding: calc(#{$grid-gutter} / 2);
+        flex: 1 1 auto;
+    }
+    // Flex item sizes
+    .flex-item {
+        &--1 {
+            flex: 0 0 8.333333%;
+        }
+        &--2 {
+            flex: 0 0 16.666667%;
+        }
+        &--3 {
+            flex: 0 0 25%;
+        }
+        &--4 {
+            flex: 0 0 33.333333%;
+        }
+        &--5 {
+            flex: 0 0 41.666667%;
+        }
+        &--6 {
+            flex: 0 0 50%;
+        }
+        &--7 {
+            flex: 0 0 58.333333%;
+        }
+        &--8 {
+            flex: 0 0 66.666667%;
+        }
+        &--9 {
+            flex: 0 0 75%;
+        }
+        &--10 {
+            flex: 0 0 83.333333%;
+        }
+        &--11 {
+            flex: 0 0 91.666667%;
+        }
+        &--12 {
+            flex: 0 0 100%;
+        }
+        &--auto {
+            flex: 1 1 auto;
+        }
+        &--none {
+            flex: none;
+        }
+        // Responsive flex items
+        @include breakpoint('md') {
+            &--md-6 {
+                flex: 0 0 50%;
+            }
+            &--md-4 {
+                flex: 0 0 33.333333%;
+            }
+            &--md-3 {
+                flex: 0 0 25%;
+            }
+            &--md-auto {
+                flex: 1 1 auto;
+            }
+        }
+        @include breakpoint('lg') {
+            &--lg-6 {
+                flex: 0 0 50%;
+            }
+            &--lg-4 {
+                flex: 0 0 33.333333%;
+            }
+            &--lg-3 {
+                flex: 0 0 25%;
+            }
+            &--lg-2 {
+                flex: 0 0 16.666667%;
+            }
+            &--lg-auto {
+                flex: 1 1 auto;
+            }
+        }
+    }
+}

--- a/assets/src/scss/layout/_spacing.scss
+++ b/assets/src/scss/layout/_spacing.scss
@@ -1,0 +1,419 @@
+/**
+ * Spacing Utilities
+ * 
+ * Consistent spacing utilities following WordPress 8px grid.
+ */
+
+.ecowitt-admin {
+    // ==========================================================================
+    // MARGIN UTILITIES
+    // ==========================================================================
+    // All sides
+    .m-0 {
+        margin: 0;
+    }
+    .m-xs {
+        margin: var(--wp-spacing-xs);
+    }
+    .m-sm {
+        margin: var(--wp-spacing-sm);
+    }
+    .m-md {
+        margin: var(--wp-spacing-md);
+    }
+    .m-lg {
+        margin: var(--wp-spacing-lg);
+    }
+    .m-xl {
+        margin: var(--wp-spacing-xl);
+    }
+    .m-xxl {
+        margin: var(--wp-spacing-xxl);
+    }
+    .m-auto {
+        margin: auto;
+    }
+    // Horizontal
+    .mx-0 {
+        margin-left: 0;
+        margin-right: 0;
+    }
+    .mx-xs {
+        margin-left: var(--wp-spacing-xs);
+        margin-right: var(--wp-spacing-xs);
+    }
+    .mx-sm {
+        margin-left: var(--wp-spacing-sm);
+        margin-right: var(--wp-spacing-sm);
+    }
+    .mx-md {
+        margin-left: var(--wp-spacing-md);
+        margin-right: var(--wp-spacing-md);
+    }
+    .mx-lg {
+        margin-left: var(--wp-spacing-lg);
+        margin-right: var(--wp-spacing-lg);
+    }
+    .mx-xl {
+        margin-left: var(--wp-spacing-xl);
+        margin-right: var(--wp-spacing-xl);
+    }
+    .mx-xxl {
+        margin-left: var(--wp-spacing-xxl);
+        margin-right: var(--wp-spacing-xxl);
+    }
+    .mx-auto {
+        margin-left: auto;
+        margin-right: auto;
+    }
+    // Vertical
+    .my-0 {
+        margin-top: 0;
+        margin-bottom: 0;
+    }
+    .my-xs {
+        margin-top: var(--wp-spacing-xs);
+        margin-bottom: var(--wp-spacing-xs);
+    }
+    .my-sm {
+        margin-top: var(--wp-spacing-sm);
+        margin-bottom: var(--wp-spacing-sm);
+    }
+    .my-md {
+        margin-top: var(--wp-spacing-md);
+        margin-bottom: var(--wp-spacing-md);
+    }
+    .my-lg {
+        margin-top: var(--wp-spacing-lg);
+        margin-bottom: var(--wp-spacing-lg);
+    }
+    .my-xl {
+        margin-top: var(--wp-spacing-xl);
+        margin-bottom: var(--wp-spacing-xl);
+    }
+    .my-xxl {
+        margin-top: var(--wp-spacing-xxl);
+        margin-bottom: var(--wp-spacing-xxl);
+    }
+    // Individual sides
+    .mt-0 {
+        margin-top: 0;
+    }
+    .mt-xs {
+        margin-top: var(--wp-spacing-xs);
+    }
+    .mt-sm {
+        margin-top: var(--wp-spacing-sm);
+    }
+    .mt-md {
+        margin-top: var(--wp-spacing-md);
+    }
+    .mt-lg {
+        margin-top: var(--wp-spacing-lg);
+    }
+    .mt-xl {
+        margin-top: var(--wp-spacing-xl);
+    }
+    .mt-xxl {
+        margin-top: var(--wp-spacing-xxl);
+    }
+    .mr-0 {
+        margin-right: 0;
+    }
+    .mr-xs {
+        margin-right: var(--wp-spacing-xs);
+    }
+    .mr-sm {
+        margin-right: var(--wp-spacing-sm);
+    }
+    .mr-md {
+        margin-right: var(--wp-spacing-md);
+    }
+    .mr-lg {
+        margin-right: var(--wp-spacing-lg);
+    }
+    .mr-xl {
+        margin-right: var(--wp-spacing-xl);
+    }
+    .mr-xxl {
+        margin-right: var(--wp-spacing-xxl);
+    }
+    .mb-0 {
+        margin-bottom: 0;
+    }
+    .mb-xs {
+        margin-bottom: var(--wp-spacing-xs);
+    }
+    .mb-sm {
+        margin-bottom: var(--wp-spacing-sm);
+    }
+    .mb-md {
+        margin-bottom: var(--wp-spacing-md);
+    }
+    .mb-lg {
+        margin-bottom: var(--wp-spacing-lg);
+    }
+    .mb-xl {
+        margin-bottom: var(--wp-spacing-xl);
+    }
+    .mb-xxl {
+        margin-bottom: var(--wp-spacing-xxl);
+    }
+    .ml-0 {
+        margin-left: 0;
+    }
+    .ml-xs {
+        margin-left: var(--wp-spacing-xs);
+    }
+    .ml-sm {
+        margin-left: var(--wp-spacing-sm);
+    }
+    .ml-md {
+        margin-left: var(--wp-spacing-md);
+    }
+    .ml-lg {
+        margin-left: var(--wp-spacing-lg);
+    }
+    .ml-xl {
+        margin-left: var(--wp-spacing-xl);
+    }
+    .ml-xxl {
+        margin-left: var(--wp-spacing-xxl);
+    }
+    // ==========================================================================
+    // PADDING UTILITIES
+    // ==========================================================================
+    // All sides
+    .p-0 {
+        padding: 0;
+    }
+    .p-xs {
+        padding: var(--wp-spacing-xs);
+    }
+    .p-sm {
+        padding: var(--wp-spacing-sm);
+    }
+    .p-md {
+        padding: var(--wp-spacing-md);
+    }
+    .p-lg {
+        padding: var(--wp-spacing-lg);
+    }
+    .p-xl {
+        padding: var(--wp-spacing-xl);
+    }
+    .p-xxl {
+        padding: var(--wp-spacing-xxl);
+    }
+    // Horizontal
+    .px-0 {
+        padding-left: 0;
+        padding-right: 0;
+    }
+    .px-xs {
+        padding-left: var(--wp-spacing-xs);
+        padding-right: var(--wp-spacing-xs);
+    }
+    .px-sm {
+        padding-left: var(--wp-spacing-sm);
+        padding-right: var(--wp-spacing-sm);
+    }
+    .px-md {
+        padding-left: var(--wp-spacing-md);
+        padding-right: var(--wp-spacing-md);
+    }
+    .px-lg {
+        padding-left: var(--wp-spacing-lg);
+        padding-right: var(--wp-spacing-lg);
+    }
+    .px-xl {
+        padding-left: var(--wp-spacing-xl);
+        padding-right: var(--wp-spacing-xl);
+    }
+    .px-xxl {
+        padding-left: var(--wp-spacing-xxl);
+        padding-right: var(--wp-spacing-xxl);
+    }
+    // Vertical
+    .py-0 {
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+    .py-xs {
+        padding-top: var(--wp-spacing-xs);
+        padding-bottom: var(--wp-spacing-xs);
+    }
+    .py-sm {
+        padding-top: var(--wp-spacing-sm);
+        padding-bottom: var(--wp-spacing-sm);
+    }
+    .py-md {
+        padding-top: var(--wp-spacing-md);
+        padding-bottom: var(--wp-spacing-md);
+    }
+    .py-lg {
+        padding-top: var(--wp-spacing-lg);
+        padding-bottom: var(--wp-spacing-lg);
+    }
+    .py-xl {
+        padding-top: var(--wp-spacing-xl);
+        padding-bottom: var(--wp-spacing-xl);
+    }
+    .py-xxl {
+        padding-top: var(--wp-spacing-xxl);
+        padding-bottom: var(--wp-spacing-xxl);
+    }
+    // Individual sides
+    .pt-0 {
+        padding-top: 0;
+    }
+    .pt-xs {
+        padding-top: var(--wp-spacing-xs);
+    }
+    .pt-sm {
+        padding-top: var(--wp-spacing-sm);
+    }
+    .pt-md {
+        padding-top: var(--wp-spacing-md);
+    }
+    .pt-lg {
+        padding-top: var(--wp-spacing-lg);
+    }
+    .pt-xl {
+        padding-top: var(--wp-spacing-xl);
+    }
+    .pt-xxl {
+        padding-top: var(--wp-spacing-xxl);
+    }
+    .pr-0 {
+        padding-right: 0;
+    }
+    .pr-xs {
+        padding-right: var(--wp-spacing-xs);
+    }
+    .pr-sm {
+        padding-right: var(--wp-spacing-sm);
+    }
+    .pr-md {
+        padding-right: var(--wp-spacing-md);
+    }
+    .pr-lg {
+        padding-right: var(--wp-spacing-lg);
+    }
+    .pr-xl {
+        padding-right: var(--wp-spacing-xl);
+    }
+    .pr-xxl {
+        padding-right: var(--wp-spacing-xxl);
+    }
+    .pb-0 {
+        padding-bottom: 0;
+    }
+    .pb-xs {
+        padding-bottom: var(--wp-spacing-xs);
+    }
+    .pb-sm {
+        padding-bottom: var(--wp-spacing-sm);
+    }
+    .pb-md {
+        padding-bottom: var(--wp-spacing-md);
+    }
+    .pb-lg {
+        padding-bottom: var(--wp-spacing-lg);
+    }
+    .pb-xl {
+        padding-bottom: var(--wp-spacing-xl);
+    }
+    .pb-xxl {
+        padding-bottom: var(--wp-spacing-xxl);
+    }
+    .pl-0 {
+        padding-left: 0;
+    }
+    .pl-xs {
+        padding-left: var(--wp-spacing-xs);
+    }
+    .pl-sm {
+        padding-left: var(--wp-spacing-sm);
+    }
+    .pl-md {
+        padding-left: var(--wp-spacing-md);
+    }
+    .pl-lg {
+        padding-left: var(--wp-spacing-lg);
+    }
+    .pl-xl {
+        padding-left: var(--wp-spacing-xl);
+    }
+    .pl-xxl {
+        padding-left: var(--wp-spacing-xxl);
+    }
+    // ==========================================================================
+    // GAP UTILITIES (for flexbox and grid)
+    // ==========================================================================
+    .gap-0 {
+        gap: 0;
+    }
+    .gap-xs {
+        gap: var(--wp-spacing-xs);
+    }
+    .gap-sm {
+        gap: var(--wp-spacing-sm);
+    }
+    .gap-md {
+        gap: var(--wp-spacing-md);
+    }
+    .gap-lg {
+        gap: var(--wp-spacing-lg);
+    }
+    .gap-xl {
+        gap: var(--wp-spacing-xl);
+    }
+    .gap-xxl {
+        gap: var(--wp-spacing-xxl);
+    }
+    // Row gap
+    .row-gap-0 {
+        row-gap: 0;
+    }
+    .row-gap-xs {
+        row-gap: var(--wp-spacing-xs);
+    }
+    .row-gap-sm {
+        row-gap: var(--wp-spacing-sm);
+    }
+    .row-gap-md {
+        row-gap: var(--wp-spacing-md);
+    }
+    .row-gap-lg {
+        row-gap: var(--wp-spacing-lg);
+    }
+    .row-gap-xl {
+        row-gap: var(--wp-spacing-xl);
+    }
+    .row-gap-xxl {
+        row-gap: var(--wp-spacing-xxl);
+    }
+    // Column gap
+    .col-gap-0 {
+        column-gap: 0;
+    }
+    .col-gap-xs {
+        column-gap: var(--wp-spacing-xs);
+    }
+    .col-gap-sm {
+        column-gap: var(--wp-spacing-sm);
+    }
+    .col-gap-md {
+        column-gap: var(--wp-spacing-md);
+    }
+    .col-gap-lg {
+        column-gap: var(--wp-spacing-lg);
+    }
+    .col-gap-xl {
+        column-gap: var(--wp-spacing-xl);
+    }
+    .col-gap-xxl {
+        column-gap: var(--wp-spacing-xxl);
+    }
+}

--- a/assets/src/scss/main.scss
+++ b/assets/src/scss/main.scss
@@ -1,0 +1,42 @@
+/**
+ * Ecowitt Weather Block - Admin Styles
+ * 
+ * A modern, professional admin interface that respects WordPress
+ * admin design patterns while providing a clean, extensible foundation.
+ * 
+ * @package EcowittWeatherBlock
+ * @since 1.0.0
+ */
+
+// ==========================================================================
+// FOUNDATION
+// ==========================================================================
+// Core abstracts - order matters
+@import 'abstracts/functions';
+@import 'abstracts/variables';
+@import 'abstracts/mixins';
+// ==========================================================================
+// VENDOR & BASE
+// ==========================================================================
+// WordPress admin compatibility
+@import 'base/wordpress-admin';
+@import 'base/reset';
+@import 'base/typography';
+// ==========================================================================
+// LAYOUT SYSTEMS
+// ==========================================================================
+@import 'layout/grid';
+@import 'layout/containers';
+@import 'layout/spacing';
+// ==========================================================================
+// UTILITIES
+// ==========================================================================
+@import 'utilities/display';
+@import 'utilities/flexbox';
+// ==========================================================================
+// COMPONENTS
+// ==========================================================================
+// Base components
+@import 'components/buttons';
+@import 'components/forms';
+@import 'components/connections';

--- a/assets/src/scss/pages/_settings.scss
+++ b/assets/src/scss/pages/_settings.scss
@@ -1,0 +1,32 @@
+/**
+ * Settings Page Styles
+ * 
+ * Settings-specific styles only.
+ */
+
+// ==========================================================================
+// SETTINGS SECTIONS
+// ==========================================================================
+.ecowitt-settings-section {
+    background: var(--wp-card-bg);
+    border: var(--wp-border-width) solid var(--wp-border-color);
+    border-radius: var(--wp-border-radius);
+    margin-bottom: var(--wp-spacing-xl);
+    overflow: hidden;
+    &__header {
+        padding: var(--wp-spacing-sm) var(--wp-spacing-md);
+        border-bottom: var(--wp-border-width) solid var(--wp-border-color);
+        background: var(--wp-color-primary);
+        color: #ffffff;
+    }
+    &__title {
+        margin: 0;
+        font-size: var(--wp-font-size-base);
+        font-weight: var(--wp-font-weight-semibold);
+        color: #ffffff;
+        text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    }
+    &__content {
+        padding: var(--wp-spacing-lg);
+    }
+}

--- a/assets/src/scss/utilities/_display.scss
+++ b/assets/src/scss/utilities/_display.scss
@@ -1,0 +1,256 @@
+/**
+ * Display Utilities
+ * 
+ * Display and visibility utilities.
+ */
+
+.ecowitt-admin {
+    // ==========================================================================
+    // DISPLAY
+    // ==========================================================================
+    .d-none {
+        display: none;
+    }
+    .d-inline {
+        display: inline;
+    }
+    .d-inline-block {
+        display: inline-block;
+    }
+    .d-block {
+        display: block;
+    }
+    .d-grid {
+        display: grid;
+    }
+    .d-inline-grid {
+        display: inline-grid;
+    }
+    .d-table {
+        display: table;
+    }
+    .d-table-row {
+        display: table-row;
+    }
+    .d-table-cell {
+        display: table-cell;
+    }
+    .d-flex {
+        display: flex;
+    }
+    .d-inline-flex {
+        display: inline-flex;
+    }
+    // Responsive display utilities
+    @include breakpoint('sm') {
+        .d-sm-none {
+            display: none;
+        }
+        .d-sm-inline {
+            display: inline;
+        }
+        .d-sm-inline-block {
+            display: inline-block;
+        }
+        .d-sm-block {
+            display: block;
+        }
+        .d-sm-grid {
+            display: grid;
+        }
+        .d-sm-flex {
+            display: flex;
+        }
+        .d-sm-inline-flex {
+            display: inline-flex;
+        }
+    }
+    @include breakpoint('md') {
+        .d-md-none {
+            display: none;
+        }
+        .d-md-inline {
+            display: inline;
+        }
+        .d-md-inline-block {
+            display: inline-block;
+        }
+        .d-md-block {
+            display: block;
+        }
+        .d-md-grid {
+            display: grid;
+        }
+        .d-md-flex {
+            display: flex;
+        }
+        .d-md-inline-flex {
+            display: inline-flex;
+        }
+    }
+    @include breakpoint('lg') {
+        .d-lg-none {
+            display: none;
+        }
+        .d-lg-inline {
+            display: inline;
+        }
+        .d-lg-inline-block {
+            display: inline-block;
+        }
+        .d-lg-block {
+            display: block;
+        }
+        .d-lg-grid {
+            display: grid;
+        }
+        .d-lg-flex {
+            display: flex;
+        }
+        .d-lg-inline-flex {
+            display: inline-flex;
+        }
+    }
+    // ==========================================================================
+    // VISIBILITY
+    // ==========================================================================
+    .visible {
+        visibility: visible;
+    }
+    .invisible {
+        visibility: hidden;
+    }
+    // ==========================================================================
+    // OVERFLOW
+    // ==========================================================================
+    .overflow-auto {
+        overflow: auto;
+    }
+    .overflow-hidden {
+        overflow: hidden;
+    }
+    .overflow-visible {
+        overflow: visible;
+    }
+    .overflow-scroll {
+        overflow: scroll;
+    }
+    .overflow-x-auto {
+        overflow-x: auto;
+    }
+    .overflow-x-hidden {
+        overflow-x: hidden;
+    }
+    .overflow-x-visible {
+        overflow-x: visible;
+    }
+    .overflow-x-scroll {
+        overflow-x: scroll;
+    }
+    .overflow-y-auto {
+        overflow-y: auto;
+    }
+    .overflow-y-hidden {
+        overflow-y: hidden;
+    }
+    .overflow-y-visible {
+        overflow-y: visible;
+    }
+    .overflow-y-scroll {
+        overflow-y: scroll;
+    }
+    // ==========================================================================
+    // POSITION
+    // ==========================================================================
+    .position-static {
+        position: static;
+    }
+    .position-relative {
+        position: relative;
+    }
+    .position-absolute {
+        position: absolute;
+    }
+    .position-fixed {
+        position: fixed;
+    }
+    .position-sticky {
+        position: sticky;
+    }
+    // ==========================================================================
+    // Z-INDEX
+    // ==========================================================================
+    .z-0 {
+        z-index: 0;
+    }
+    .z-10 {
+        z-index: 10;
+    }
+    .z-20 {
+        z-index: 20;
+    }
+    .z-30 {
+        z-index: 30;
+    }
+    .z-40 {
+        z-index: 40;
+    }
+    .z-50 {
+        z-index: 50;
+    }
+    .z-dropdown {
+        z-index: var(--wp-z-dropdown);
+    }
+    .z-sticky {
+        z-index: var(--wp-z-sticky);
+    }
+    .z-fixed {
+        z-index: var(--wp-z-fixed);
+    }
+    .z-modal-backdrop {
+        z-index: var(--wp-z-modal-backdrop);
+    }
+    .z-modal {
+        z-index: var(--wp-z-modal);
+    }
+    .z-popover {
+        z-index: var(--wp-z-popover);
+    }
+    .z-tooltip {
+        z-index: var(--wp-z-tooltip);
+    }
+    // ==========================================================================
+    // OPACITY
+    // ==========================================================================
+    .opacity-0 {
+        opacity: 0;
+    }
+    .opacity-25 {
+        opacity: 0.25;
+    }
+    .opacity-50 {
+        opacity: 0.5;
+    }
+    .opacity-75 {
+        opacity: 0.75;
+    }
+    .opacity-100 {
+        opacity: 1;
+    }
+    // ==========================================================================
+    // SCREEN READERS
+    // ==========================================================================
+    .sr-only {
+        @include sr-only;
+    }
+    .not-sr-only {
+        position: static;
+        width: auto;
+        height: auto;
+        padding: inherit;
+        margin: inherit;
+        overflow: visible;
+        clip: auto;
+        white-space: normal;
+    }
+}

--- a/assets/src/scss/utilities/_flexbox.scss
+++ b/assets/src/scss/utilities/_flexbox.scss
@@ -1,0 +1,268 @@
+/**
+ * Flexbox Utilities
+ * 
+ * Comprehensive flexbox utilities for layout.
+ */
+
+.ecowitt-admin {
+    // ==========================================================================
+    // FLEX CONTAINER
+    // ==========================================================================
+    .flex {
+        display: flex;
+    }
+    .inline-flex {
+        display: inline-flex;
+    }
+    // ==========================================================================
+    // FLEX DIRECTION
+    // ==========================================================================
+    .flex-row {
+        flex-direction: row;
+    }
+    .flex-row-reverse {
+        flex-direction: row-reverse;
+    }
+    .flex-col {
+        flex-direction: column;
+    }
+    .flex-col-reverse {
+        flex-direction: column-reverse;
+    }
+    // ==========================================================================
+    // FLEX WRAP
+    // ==========================================================================
+    .flex-wrap {
+        flex-wrap: wrap;
+    }
+    .flex-wrap-reverse {
+        flex-wrap: wrap-reverse;
+    }
+    .flex-nowrap {
+        flex-wrap: nowrap;
+    }
+    // ==========================================================================
+    // FLEX ITEMS
+    // ==========================================================================
+    .flex-1 {
+        flex: 1 1 0%;
+    }
+    .flex-auto {
+        flex: 1 1 auto;
+    }
+    .flex-initial {
+        flex: 0 1 auto;
+    }
+    .flex-none {
+        flex: none;
+    }
+    // ==========================================================================
+    // FLEX GROW
+    // ==========================================================================
+    .flex-grow-0 {
+        flex-grow: 0;
+    }
+    .flex-grow {
+        flex-grow: 1;
+    }
+    // ==========================================================================
+    // FLEX SHRINK
+    // ==========================================================================
+    .flex-shrink-0 {
+        flex-shrink: 0;
+    }
+    .flex-shrink {
+        flex-shrink: 1;
+    }
+    // ==========================================================================
+    // JUSTIFY CONTENT
+    // ==========================================================================
+    .justify-start {
+        justify-content: flex-start;
+    }
+    .justify-end {
+        justify-content: flex-end;
+    }
+    .justify-center {
+        justify-content: center;
+    }
+    .justify-between {
+        justify-content: space-between;
+    }
+    .justify-around {
+        justify-content: space-around;
+    }
+    .justify-evenly {
+        justify-content: space-evenly;
+    }
+    // ==========================================================================
+    // ALIGN ITEMS
+    // ==========================================================================
+    .items-start {
+        align-items: flex-start;
+    }
+    .items-end {
+        align-items: flex-end;
+    }
+    .items-center {
+        align-items: center;
+    }
+    .items-baseline {
+        align-items: baseline;
+    }
+    .items-stretch {
+        align-items: stretch;
+    }
+    // ==========================================================================
+    // ALIGN CONTENT
+    // ==========================================================================
+    .content-start {
+        align-content: flex-start;
+    }
+    .content-end {
+        align-content: flex-end;
+    }
+    .content-center {
+        align-content: center;
+    }
+    .content-between {
+        align-content: space-between;
+    }
+    .content-around {
+        align-content: space-around;
+    }
+    .content-evenly {
+        align-content: space-evenly;
+    }
+    // ==========================================================================
+    // ALIGN SELF
+    // ==========================================================================
+    .self-auto {
+        align-self: auto;
+    }
+    .self-start {
+        align-self: flex-start;
+    }
+    .self-end {
+        align-self: flex-end;
+    }
+    .self-center {
+        align-self: center;
+    }
+    .self-stretch {
+        align-self: stretch;
+    }
+    .self-baseline {
+        align-self: baseline;
+    }
+    // ==========================================================================
+    // COMMON FLEX PATTERNS
+    // ==========================================================================
+    .flex-center {
+        @include flex-center;
+    }
+    .flex-between {
+        @include flex-between;
+    }
+    .flex-column {
+        @include flex-column;
+    }
+    .flex-column-center {
+        @include flex-column;
+        align-items: center;
+    }
+    .flex-column-between {
+        @include flex-column;
+        justify-content: space-between;
+    }
+    // ==========================================================================
+    // RESPONSIVE FLEXBOX
+    // ==========================================================================
+    @include breakpoint('sm') {
+        .sm\:flex {
+            display: flex;
+        }
+        .sm\:flex-row {
+            flex-direction: row;
+        }
+        .sm\:flex-col {
+            flex-direction: column;
+        }
+        .sm\:justify-start {
+            justify-content: flex-start;
+        }
+        .sm\:justify-center {
+            justify-content: center;
+        }
+        .sm\:justify-between {
+            justify-content: space-between;
+        }
+        .sm\:items-start {
+            align-items: flex-start;
+        }
+        .sm\:items-center {
+            align-items: center;
+        }
+        .sm\:items-end {
+            align-items: flex-end;
+        }
+    }
+    @include breakpoint('md') {
+        .md\:flex {
+            display: flex;
+        }
+        .md\:flex-row {
+            flex-direction: row;
+        }
+        .md\:flex-col {
+            flex-direction: column;
+        }
+        .md\:justify-start {
+            justify-content: flex-start;
+        }
+        .md\:justify-center {
+            justify-content: center;
+        }
+        .md\:justify-between {
+            justify-content: space-between;
+        }
+        .md\:items-start {
+            align-items: flex-start;
+        }
+        .md\:items-center {
+            align-items: center;
+        }
+        .md\:items-end {
+            align-items: flex-end;
+        }
+    }
+    @include breakpoint('lg') {
+        .lg\:flex {
+            display: flex;
+        }
+        .lg\:flex-row {
+            flex-direction: row;
+        }
+        .lg\:flex-col {
+            flex-direction: column;
+        }
+        .lg\:justify-start {
+            justify-content: flex-start;
+        }
+        .lg\:justify-center {
+            justify-content: center;
+        }
+        .lg\:justify-between {
+            justify-content: space-between;
+        }
+        .lg\:items-start {
+            align-items: flex-start;
+        }
+        .lg\:items-center {
+            align-items: center;
+        }
+        .lg\:items-end {
+            align-items: flex-end;
+        }
+    }
+}

--- a/assets/src/scss/utilities/_spacing.scss
+++ b/assets/src/scss/utilities/_spacing.scss
@@ -1,0 +1,10 @@
+/**
+ * Spacing Utilities
+ * 
+ * Already created in layout/_spacing.scss, but creating alias here for utilities
+ */
+
+// This file serves as an alias to layout/spacing utilities
+// The actual spacing utilities are defined in layout/_spacing.scss
+// This import structure allows for better organization
+// Re-export spacing utilities that were defined in layout/_spacing.scss

--- a/assets/src/scss/utilities/_typography.scss
+++ b/assets/src/scss/utilities/_typography.scss
@@ -1,0 +1,173 @@
+/**
+ * Typography Utilities
+ * 
+ * Additional typography utility classes beyond base typography.
+ */
+
+.ecowitt-admin {
+    // ==========================================================================
+    // FONT SIZES
+    // ==========================================================================
+    .text-xs {
+        font-size: var(--wp-font-size-xs) !important;
+    }
+    .text-sm {
+        font-size: var(--wp-font-size-sm) !important;
+    }
+    .text-base {
+        font-size: var(--wp-font-size-base) !important;
+    }
+    .text-md {
+        font-size: var(--wp-font-size-md) !important;
+    }
+    .text-lg {
+        font-size: var(--wp-font-size-lg) !important;
+    }
+    .text-xl {
+        font-size: var(--wp-font-size-xl) !important;
+    }
+    .text-xxl {
+        font-size: var(--wp-font-size-xxl) !important;
+    }
+    // ==========================================================================
+    // FONT WEIGHTS
+    // ==========================================================================
+    .font-normal {
+        font-weight: var(--wp-font-weight-normal) !important;
+    }
+    .font-medium {
+        font-weight: var(--wp-font-weight-medium) !important;
+    }
+    .font-semibold {
+        font-weight: var(--wp-font-weight-semibold) !important;
+    }
+    .font-bold {
+        font-weight: var(--wp-font-weight-bold) !important;
+    }
+    // ==========================================================================
+    // LINE HEIGHTS
+    // ==========================================================================
+    .leading-tight {
+        line-height: var(--wp-line-height-tight) !important;
+    }
+    .leading-normal {
+        line-height: var(--wp-line-height-normal) !important;
+    }
+    .leading-relaxed {
+        line-height: var(--wp-line-height-relaxed) !important;
+    }
+    // ==========================================================================
+    // TEXT ALIGNMENT
+    // ==========================================================================
+    .text-left {
+        text-align: left !important;
+    }
+    .text-center {
+        text-align: center !important;
+    }
+    .text-right {
+        text-align: right !important;
+    }
+    .text-justify {
+        text-align: justify !important;
+    }
+    // ==========================================================================
+    // TEXT TRANSFORM
+    // ==========================================================================
+    .uppercase {
+        text-transform: uppercase !important;
+    }
+    .lowercase {
+        text-transform: lowercase !important;
+    }
+    .capitalize {
+        text-transform: capitalize !important;
+    }
+    .normal-case {
+        text-transform: none !important;
+    }
+    // ==========================================================================
+    // TEXT DECORATION
+    // ==========================================================================
+    .underline {
+        text-decoration: underline !important;
+    }
+    .line-through {
+        text-decoration: line-through !important;
+    }
+    .no-underline {
+        text-decoration: none !important;
+    }
+    // ==========================================================================
+    // WHITE SPACE
+    // ==========================================================================
+    .whitespace-normal {
+        white-space: normal !important;
+    }
+    .whitespace-nowrap {
+        white-space: nowrap !important;
+    }
+    .whitespace-pre {
+        white-space: pre !important;
+    }
+    .whitespace-pre-line {
+        white-space: pre-line !important;
+    }
+    .whitespace-pre-wrap {
+        white-space: pre-wrap !important;
+    }
+    // ==========================================================================
+    // TEXT OVERFLOW
+    // ==========================================================================
+    .truncate {
+        @include truncate;
+    }
+    .text-ellipsis {
+        text-overflow: ellipsis !important;
+    }
+    .text-clip {
+        text-overflow: clip !important;
+    }
+    // ==========================================================================
+    // LINE CLAMPING
+    // ==========================================================================
+    .line-clamp-1 {
+        @include line-clamp(1);
+    }
+    .line-clamp-2 {
+        @include line-clamp(2);
+    }
+    .line-clamp-3 {
+        @include line-clamp(3);
+    }
+    .line-clamp-4 {
+        @include line-clamp(4);
+    }
+    .line-clamp-5 {
+        @include line-clamp(5);
+    }
+    .line-clamp-6 {
+        @include line-clamp(6);
+    }
+    // ==========================================================================
+    // LETTER SPACING
+    // ==========================================================================
+    .tracking-tighter {
+        letter-spacing: -0.05em !important;
+    }
+    .tracking-tight {
+        letter-spacing: -0.025em !important;
+    }
+    .tracking-normal {
+        letter-spacing: 0em !important;
+    }
+    .tracking-wide {
+        letter-spacing: 0.025em !important;
+    }
+    .tracking-wider {
+        letter-spacing: 0.05em !important;
+    }
+    .tracking-widest {
+        letter-spacing: 0.1em !important;
+    }
+}

--- a/assets/src/scss_OLD/abstracts/_functions.scss
+++ b/assets/src/scss_OLD/abstracts/_functions.scss
@@ -1,0 +1,72 @@
+/**
+ * Functions
+ * 
+ * SCSS functions for common calculations and utilities.
+ */
+
+// ==========================================================================
+// SPACING FUNCTIONS
+// ==========================================================================
+/// Calculate spacing based on the base unit
+/// @param {Number} $multiplier - Multiplier for the base spacing unit
+/// @return {Length} - Calculated spacing value
+@function spacing($multiplier) {
+    @return $spacing-unit * $multiplier;
+}
+
+/// Convert px to rem based on WordPress base font size (13px)
+/// @param {Number} $pixels - Pixel value to convert
+/// @param {Number} $base-font-size - Base font size (default: 13px)
+/// @return {Length} - Rem value
+@function px-to-rem($pixels, $base-font-size: 13px) {
+    @return ($pixels / $base-font-size) * 1rem;
+}
+
+// ==========================================================================
+// COLOR FUNCTIONS
+// ==========================================================================
+/// Lighten a color by a percentage
+/// @param {Color} $color - Base color
+/// @param {Number} $percentage - Percentage to lighten
+/// @return {Color} - Lightened color
+@function lighten-color($color, $percentage) {
+    @return lighten($color, $percentage);
+}
+
+/// Darken a color by a percentage
+/// @param {Color} $color - Base color
+/// @param {Number} $percentage - Percentage to darken
+/// @return {Color} - Darkened color
+@function darken-color($color, $percentage) {
+    @return darken($color, $percentage);
+}
+
+/// Create a transparent version of a color
+/// @param {Color} $color - Base color
+/// @param {Number} $alpha - Alpha value (0-1)
+/// @return {Color} - Color with transparency
+@function alpha-color($color, $alpha) {
+    @return rgba($color, $alpha);
+}
+
+// ==========================================================================
+// LAYOUT FUNCTIONS
+// ==========================================================================
+/// Calculate container max-width with padding
+/// @param {Length} $width - Base width
+/// @param {Length} $padding - Padding to subtract
+/// @return {Length} - Calculated width
+@function container-width($width, $padding: $spacing-md) {
+    @return $width - ($padding * 2);
+}
+
+/// Calculate grid column width
+/// @param {Number} $columns - Number of columns to span
+/// @param {Number} $total-columns - Total columns in grid (default: 12)
+/// @param {Length} $gutter - Gutter width (default: $grid-gutter)
+/// @return {Length} - Calculated width percentage
+@function grid-width($columns, $total-columns: $grid-columns, $gutter: $grid-gutter) {
+    $column-width: (100% - ($gutter * ($total-columns - 1))) / $total-columns;
+    $span-width: ($column-width * $columns) + ($gutter * ($columns - 1));
+    @return $span-width;
+}

--- a/assets/src/scss_OLD/abstracts/_mixins.scss
+++ b/assets/src/scss_OLD/abstracts/_mixins.scss
@@ -1,0 +1,310 @@
+/**
+ * Mixins
+ * 
+ * Reusable mixins for common patterns and utilities.
+ */
+
+// ==========================================================================
+// LAYOUT MIXINS
+// ==========================================================================
+/// Clear floats
+@mixin clearfix {
+    &::after {
+        content: "";
+        display: table;
+        clear: both;
+    }
+}
+
+/// Center an element horizontally and vertically
+@mixin center {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}
+
+/// Center an element horizontally
+@mixin center-x {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+}
+
+/// Center an element vertically
+@mixin center-y {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+/// Flexbox center alignment
+@mixin flex-center {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+/// Container with max-width and padding
+@mixin container($max-width: $container-lg, $padding: $spacing-md) {
+    width: 100%;
+    max-width: $max-width;
+    margin: 0 auto;
+    padding-left: $padding;
+    padding-right: $padding;
+}
+
+// ==========================================================================
+// BUTTON MIXINS
+// ==========================================================================
+/// Base button styles
+@mixin button-base {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-family: $font-base;
+    font-size: $font-size-base;
+    font-weight: $font-weight-medium;
+    line-height: 1;
+    text-decoration: none;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+    cursor: pointer;
+    user-select: none;
+    border: $border-width solid transparent;
+    border-radius: $border-radius-md;
+    padding: spacing(1) spacing(2);
+    transition: all $transition-fast $easing-ease;
+    &:focus {
+        outline: 2px solid $wp-admin-blue;
+        outline-offset: 2px;
+    }
+    &:disabled,
+    &.disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+        pointer-events: none;
+    }
+}
+
+/// Button size variants
+@mixin button-sm {
+    font-size: $font-size-sm;
+    padding: spacing(0.5) spacing(1.5);
+}
+
+@mixin button-lg {
+    font-size: $font-size-md;
+    padding: spacing(1.5) spacing(3);
+}
+
+/// Button color variants
+@mixin button-variant($bg-color, $text-color: $white, $hover-bg: null, $hover-text: null) {
+    background-color: $bg-color;
+    color: $text-color;
+    border-color: $bg-color;
+    @if $hover-bg==null {
+        $hover-bg: darken($bg-color, 8%);
+    }
+    @if $hover-text==null {
+        $hover-text: $text-color;
+    }
+    &:hover,
+    &:focus {
+        background-color: $hover-bg;
+        color: $hover-text;
+        border-color: $hover-bg;
+        text-decoration: none;
+    }
+    &:active {
+        background-color: darken($hover-bg, 5%);
+        border-color: darken($hover-bg, 5%);
+    }
+}
+
+// ==========================================================================
+// FORM MIXINS
+// ==========================================================================
+/// Base form control styles
+@mixin form-control-base {
+    display: block;
+    width: 100%;
+    font-family: $font-base;
+    font-size: $font-size-base;
+    font-weight: $font-weight-normal;
+    line-height: $line-height-normal;
+    color: $gray-700;
+    background-color: $white;
+    background-clip: padding-box;
+    border: $border-width solid $gray-300;
+    border-radius: $border-radius-md;
+    padding: spacing(1) spacing(1.5);
+    transition: border-color $transition-fast $easing-ease, box-shadow $transition-fast $easing-ease;
+    &:focus {
+        outline: 0;
+        border-color: $wp-admin-blue;
+        box-shadow: 0 0 0 2px alpha-color($wp-admin-blue, 0.2);
+    }
+    &:disabled,
+    &[readonly] {
+        background-color: $gray-100;
+        opacity: 1;
+    }
+    &::placeholder {
+        color: $gray-500;
+        opacity: 1;
+    }
+}
+
+/// Form group spacing
+@mixin form-group {
+    margin-bottom: $spacing-lg;
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+/// Form label styles
+@mixin form-label {
+    display: inline-block;
+    font-weight: $font-weight-medium;
+    color: $gray-700;
+    margin-bottom: spacing(0.5);
+}
+
+// ==========================================================================
+// CARD MIXINS
+// ==========================================================================
+/// Base card styles
+@mixin card-base {
+    background-color: $white;
+    border: $border-width solid $gray-200;
+    border-radius: $border-radius-lg;
+    box-shadow: $shadow-sm;
+}
+
+/// Card padding variants
+@mixin card-padding($size: 'md') {
+    @if $size=='sm' {
+        padding: $spacing-md;
+    }
+    @else if $size=='lg' {
+        padding: $spacing-xl;
+    }
+    @else {
+        padding: $spacing-lg;
+    }
+}
+
+// ==========================================================================
+// RESPONSIVE MIXINS
+// ==========================================================================
+/// Media query breakpoints
+@mixin mobile-up {
+    @media (min-width: 480px) {
+        @content;
+    }
+}
+
+@mixin tablet-up {
+    @media (min-width: 768px) {
+        @content;
+    }
+}
+
+@mixin desktop-up {
+    @media (min-width: 992px) {
+        @content;
+    }
+}
+
+@mixin large-up {
+    @media (min-width: 1200px) {
+        @content;
+    }
+}
+
+// ==========================================================================
+// ACCESSIBILITY MIXINS
+// ==========================================================================
+/// Screen reader only text
+@mixin sr-only {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
+
+/// Focus styles for keyboard navigation
+@mixin focus-visible {
+    &:focus-visible {
+        outline: 2px solid $wp-admin-blue;
+        outline-offset: 2px;
+    }
+}
+
+// ==========================================================================
+// ANIMATION MIXINS
+// ==========================================================================
+/// Fade in animation
+@mixin fade-in($duration: $transition-normal) {
+    opacity: 0;
+    animation: fadeIn $duration $easing-ease-out forwards;
+}
+
+@keyframes fadeIn {
+    to {
+        opacity: 1;
+    }
+}
+
+/// Slide in from top
+@mixin slide-in-top($duration: $transition-normal) {
+    opacity: 0;
+    transform: translateY(-20px);
+    animation: slideInTop $duration $easing-ease-out forwards;
+}
+
+@keyframes slideInTop {
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+// ==========================================================================
+// RESPONSIVE MIXINS
+// ==========================================================================
+/// Mobile only (max-width: 767px)
+@mixin mobile-only {
+    @media (max-width: 767px) {
+        @content;
+    }
+}
+
+/// Tablet and up (min-width: 768px)
+@mixin tablet-up {
+    @media (min-width: 768px) {
+        @content;
+    }
+}
+
+/// Desktop and up (min-width: 1024px)
+@mixin desktop-up {
+    @media (min-width: 1024px) {
+        @content;
+    }
+}
+
+/// Large desktop and up (min-width: 1200px)
+@mixin desktop-large-up {
+    @media (min-width: 1200px) {
+        @content;
+    }
+}

--- a/assets/src/scss_OLD/abstracts/_variables.scss
+++ b/assets/src/scss_OLD/abstracts/_variables.scss
@@ -1,0 +1,133 @@
+/**
+ * Variables
+ * 
+ * Design tokens and variables used throughout the admin styles.
+ * Following WordPress admin color scheme and spacing conventions.
+ */
+
+// ==========================================================================
+// COLORS
+// ==========================================================================
+// WordPress Admin Colors
+$wp-admin-blue: #0073aa;
+$wp-admin-blue-dark: #005177;
+$wp-admin-blue-light: #00a0d2;
+// WordPress UI Colors
+$wp-success: #46b450;
+$wp-warning: #ffb900;
+$wp-error: #dc3232;
+$wp-info: #00a0d2;
+// Neutral Colors
+$white: #ffffff;
+$gray-50: #f9f9f9;
+$gray-100: #f1f1f1;
+$gray-200: #e1e1e1;
+$gray-300: #ccd0d4;
+$gray-400: #a7aaad;
+$gray-500: #8c8f94;
+$gray-600: #646970;
+$gray-700: #3c434a;
+$gray-800: #1d2327;
+$gray-900: #000000;
+// Component Colors
+$connection-border: $gray-200;
+$connection-bg: $white;
+$connection-shadow: rgba(0, 0, 0, 0.05);
+// Button Colors
+$btn-primary-bg: $wp-admin-blue;
+$btn-primary-hover: $wp-admin-blue-dark;
+$btn-secondary-bg: $gray-100;
+$btn-secondary-hover: $gray-200;
+$btn-danger-bg: $wp-error;
+$btn-danger-hover: darken($wp-error, 10%);
+// ==========================================================================
+// TYPOGRAPHY
+// ==========================================================================
+// Font Families (WordPress defaults)
+$font-base: -apple-system,
+BlinkMacSystemFont,
+"Segoe UI",
+Roboto,
+Oxygen-Sans,
+Ubuntu,
+Cantarell,
+"Helvetica Neue",
+sans-serif;
+$font-mono: Consolas,
+Monaco,
+monospace;
+// Font Sizes
+$font-size-xs: 11px;
+$font-size-sm: 12px;
+$font-size-base: 13px;
+$font-size-md: 14px;
+$font-size-lg: 18px;
+$font-size-xl: 24px;
+$font-size-xxl: 32px;
+// Font Weights
+$font-weight-light: 300;
+$font-weight-normal: 400;
+$font-weight-medium: 500;
+$font-weight-semibold: 600;
+$font-weight-bold: 700;
+// Line Heights
+$line-height-tight: 1.2;
+$line-height-normal: 1.4;
+$line-height-relaxed: 1.6;
+// ==========================================================================
+// SPACING
+// ==========================================================================
+// Base spacing unit (WordPress uses 8px grid)
+$spacing-unit: 8px;
+// Spacing Scale
+$spacing-xs: $spacing-unit * 0.5; // 4px
+$spacing-sm: $spacing-unit * 1; // 8px
+$spacing-md: $spacing-unit * 2; // 16px
+$spacing-lg: $spacing-unit * 3; // 24px
+$spacing-xl: $spacing-unit * 4; // 32px
+$spacing-xxl: $spacing-unit * 6; // 48px
+$spacing-xxxl: $spacing-unit * 8; // 64px
+// ==========================================================================
+// LAYOUT
+// ==========================================================================
+// Container widths
+$container-sm: 576px;
+$container-md: 768px;
+$container-lg: 992px;
+$container-xl: 1200px;
+// Grid
+$grid-columns: 12;
+$grid-gutter: $spacing-md;
+// ==========================================================================
+// BORDERS & RADIUS
+// ==========================================================================
+$border-width: 1px;
+$border-radius-sm: 3px;
+$border-radius-md: 4px;
+$border-radius-lg: 6px;
+// ==========================================================================
+// SHADOWS
+// ==========================================================================
+$shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.1);
+$shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+$shadow-lg: 0 10px 15px rgba(0, 0, 0, 0.1);
+// ==========================================================================
+// TRANSITIONS
+// ==========================================================================
+$transition-fast: 0.15s;
+$transition-normal: 0.25s;
+$transition-slow: 0.35s;
+$easing-ease: ease;
+$easing-ease-in: ease-in;
+$easing-ease-out: ease-out;
+$easing-ease-in-out: ease-in-out;
+// ==========================================================================
+// Z-INDEX SCALE
+// ==========================================================================
+$z-dropdown: 1000;
+$z-sticky: 1020;
+$z-fixed: 1030;
+$z-modal-backdrop: 1040;
+$z-modal: 1050;
+$z-popover: 1060;
+$z-tooltip: 1070;

--- a/assets/src/scss_OLD/admin.scss
+++ b/assets/src/scss_OLD/admin.scss
@@ -1,0 +1,35 @@
+/**
+ * Admin Styles for Ecowitt Weather Block
+ * 
+ * Main entry point for all admin styles.
+ * This file imports all partial SCSS files in the correct order.
+ */
+
+// ==========================================================================
+// ABSTRACTS
+// ==========================================================================
+@import 'abstracts/variables';
+@import 'abstracts/functions';
+@import 'abstracts/mixins';
+// ==========================================================================
+// BASE
+// ==========================================================================
+@import 'base/reset';
+@import 'base/typography';
+// ==========================================================================
+// LAYOUT
+// ==========================================================================
+@import 'layout/admin-page';
+@import 'layout/settings-page';
+// ==========================================================================
+// COMPONENTS
+// ==========================================================================
+@import 'components/buttons';
+@import 'components/forms';
+@import 'components/connections';
+@import 'components/notifications';
+// ==========================================================================
+// UTILITIES
+// ==========================================================================
+@import 'utilities/spacing';
+@import 'utilities/helpers';

--- a/assets/src/scss_OLD/base/_reset.scss
+++ b/assets/src/scss_OLD/base/_reset.scss
@@ -1,0 +1,144 @@
+/**
+ * Reset
+ * 
+ * Admin-specific resets to ensure consistent styling across WordPress admin.
+ * These are scoped to avoid conflicts with WordPress core admin styles.
+ */
+
+// ==========================================================================
+// SCOPED ADMIN RESETS
+// ==========================================================================
+// Scope all styles to our plugin's admin pages
+.ecowitt-admin {
+    // Box sizing reset
+    *,
+    *::before,
+    *::after {
+        box-sizing: border-box;
+    }
+    // Remove default margins and padding on specific elements
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p,
+    ul,
+    ol,
+    li,
+    blockquote,
+    figure,
+    figcaption {
+        margin: 0;
+        padding: 0;
+    }
+    // Reset list styles
+    ul,
+    ol {
+        list-style: none;
+    }
+    // Reset button styles
+    button {
+        background: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        font: inherit;
+        color: inherit;
+        cursor: pointer;
+    }
+    // Reset input styles
+    input,
+    textarea,
+    select {
+        font: inherit;
+        color: inherit;
+    }
+    // Reset link styles within admin
+    a {
+        color: inherit;
+        text-decoration: none;
+        &:hover,
+        &:focus {
+            text-decoration: none;
+        }
+    }
+    // Reset table styles
+    table {
+        border-collapse: collapse;
+        border-spacing: 0;
+    }
+    // Reset image styles
+    img {
+        max-width: 100%;
+        height: auto;
+    }
+    // Reset fieldset and legend
+    fieldset {
+        border: none;
+        margin: 0;
+        padding: 0;
+    }
+    legend {
+        padding: 0;
+    }
+}
+
+// ==========================================================================
+// WORDPRESS ADMIN OVERRIDES
+// ==========================================================================
+// Ensure our components don't inherit unwanted WordPress admin styles
+.ecowitt-admin {
+    // Override WordPress admin form table styles for our forms
+    .form-table {
+        border-collapse: separate;
+        border-spacing: 0;
+        margin: 0;
+        width: 100%;
+        th,
+        td {
+            padding: $spacing-md;
+            vertical-align: top;
+            border: none;
+            background: none;
+        }
+        th {
+            font-weight: $font-weight-medium;
+            text-align: left;
+            width: auto;
+        }
+    }
+    // Override WordPress button styles for our buttons
+    .button {
+        @include button-base;
+        // Remove WordPress default styles
+        font-size: inherit;
+        line-height: inherit;
+        padding: inherit;
+        height: auto;
+        min-height: auto;
+        text-shadow: none;
+        box-shadow: none;
+        border-radius: $border-radius-md;
+        &:hover,
+        &:focus {
+            box-shadow: none;
+        }
+    }
+    // Ensure our inputs don't inherit WordPress admin styles
+    input[type="text"],
+    input[type="email"],
+    input[type="password"],
+    input[type="url"],
+    input[type="number"],
+    textarea,
+    select {
+        @include form-control-base;
+        // Remove WordPress default styles
+        box-shadow: none;
+        &:focus {
+            box-shadow: 0 0 0 2px alpha-color($wp-admin-blue, 0.2);
+        }
+    }
+}

--- a/assets/src/scss_OLD/base/_typography.scss
+++ b/assets/src/scss_OLD/base/_typography.scss
@@ -1,0 +1,261 @@
+/**
+ * Typography
+ * 
+ * Typography styles for admin interface.
+ * Builds on WordPress admin typography while maintaining consistency.
+ */
+
+// ==========================================================================
+// BASE TYPOGRAPHY
+// ==========================================================================
+.ecowitt-admin {
+    // Base font settings
+    font-family: $font-base;
+    font-size: $font-size-base;
+    line-height: $line-height-normal;
+    color: $gray-700;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    // ==========================================================================
+    // HEADINGS
+    // ==========================================================================
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+        font-family: $font-base;
+        font-weight: $font-weight-semibold;
+        line-height: $line-height-tight;
+        color: $gray-800;
+        margin-bottom: $spacing-md;
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+    h1 {
+        font-size: $font-size-xxl;
+        font-weight: $font-weight-bold;
+        margin-bottom: $spacing-lg;
+    }
+    h2 {
+        font-size: $font-size-xl;
+        margin-bottom: $spacing-lg;
+    }
+    h3 {
+        font-size: $font-size-lg;
+        margin-bottom: $spacing-md;
+    }
+    h4 {
+        font-size: $font-size-md;
+        margin-bottom: $spacing-md;
+    }
+    h5 {
+        font-size: $font-size-base;
+        margin-bottom: $spacing-sm;
+    }
+    h6 {
+        font-size: $font-size-sm;
+        font-weight: $font-weight-bold;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+        margin-bottom: $spacing-sm;
+    }
+    // ==========================================================================
+    // PARAGRAPHS & TEXT
+    // ==========================================================================
+    p {
+        margin-bottom: $spacing-md;
+        &:last-child {
+            margin-bottom: 0;
+        }
+        &.lead {
+            font-size: $font-size-md;
+            font-weight: $font-weight-normal;
+            color: $gray-600;
+            line-height: $line-height-relaxed;
+        }
+        &.small {
+            font-size: $font-size-sm;
+            color: $gray-500;
+        }
+    }
+    // ==========================================================================
+    // INLINE TEXT ELEMENTS
+    // ==========================================================================
+    strong,
+    b {
+        font-weight: $font-weight-bold;
+    }
+    em,
+    i {
+        font-style: italic;
+    }
+    small {
+        font-size: $font-size-sm;
+        color: $gray-500;
+    }
+    mark {
+        background-color: lighten($wp-warning, 30%);
+        padding: 0.125em 0.25em;
+        border-radius: $border-radius-sm;
+    }
+    code {
+        font-family: $font-mono;
+        font-size: 0.9em;
+        background-color: $gray-100;
+        padding: 0.125em 0.375em;
+        border-radius: $border-radius-sm;
+        border: 1px solid $gray-200;
+    }
+    // ==========================================================================
+    // LINKS
+    // ==========================================================================
+    a {
+        color: $wp-admin-blue;
+        text-decoration: none;
+        transition: color $transition-fast $easing-ease;
+        &:hover,
+        &:focus {
+            color: $wp-admin-blue-dark;
+            text-decoration: underline;
+        }
+        &:active {
+            color: $wp-admin-blue-dark;
+        }
+        // Link variants
+        &.link-muted {
+            color: $gray-500;
+            &:hover,
+            &:focus {
+                color: $gray-700;
+            }
+        }
+        &.link-danger {
+            color: $wp-error;
+            &:hover,
+            &:focus {
+                color: darken($wp-error, 10%);
+            }
+        }
+    }
+    // ==========================================================================
+    // LISTS
+    // ==========================================================================
+    ul,
+    ol {
+        margin-bottom: $spacing-md;
+        padding-left: $spacing-lg;
+        &:last-child {
+            margin-bottom: 0;
+        }
+        li {
+            margin-bottom: spacing(0.5);
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+    ul {
+        list-style-type: disc;
+        ul {
+            list-style-type: circle;
+            margin-top: spacing(0.5);
+            margin-bottom: 0;
+        }
+    }
+    ol {
+        list-style-type: decimal;
+        ol {
+            list-style-type: lower-alpha;
+            margin-top: spacing(0.5);
+            margin-bottom: 0;
+        }
+    }
+    // Unstyled lists
+    .list-unstyled {
+        padding-left: 0;
+        list-style: none;
+    }
+    // Inline lists
+    .list-inline {
+        padding-left: 0;
+        list-style: none;
+        li {
+            display: inline-block;
+            margin-right: $spacing-md;
+            margin-bottom: 0;
+            &:last-child {
+                margin-right: 0;
+            }
+        }
+    }
+    // ==========================================================================
+    // UTILITY CLASSES
+    // ==========================================================================
+    // Text alignment
+    .text-left {
+        text-align: left;
+    }
+    .text-center {
+        text-align: center;
+    }
+    .text-right {
+        text-align: right;
+    }
+    // Text colors
+    .text-muted {
+        color: $gray-500;
+    }
+    .text-primary {
+        color: $wp-admin-blue;
+    }
+    .text-success {
+        color: $wp-success;
+    }
+    .text-warning {
+        color: $wp-warning;
+    }
+    .text-danger {
+        color: $wp-error;
+    }
+    // Font weights
+    .font-light {
+        font-weight: $font-weight-light;
+    }
+    .font-normal {
+        font-weight: $font-weight-normal;
+    }
+    .font-medium {
+        font-weight: $font-weight-medium;
+    }
+    .font-semibold {
+        font-weight: $font-weight-semibold;
+    }
+    .font-bold {
+        font-weight: $font-weight-bold;
+    }
+    // Font sizes
+    .text-xs {
+        font-size: $font-size-xs;
+    }
+    .text-sm {
+        font-size: $font-size-sm;
+    }
+    .text-base {
+        font-size: $font-size-base;
+    }
+    .text-md {
+        font-size: $font-size-md;
+    }
+    .text-lg {
+        font-size: $font-size-lg;
+    }
+    .text-xl {
+        font-size: $font-size-xl;
+    }
+    .text-xxl {
+        font-size: $font-size-xxl;
+    }
+}

--- a/assets/src/scss_OLD/components/_buttons.scss
+++ b/assets/src/scss_OLD/components/_buttons.scss
@@ -1,0 +1,280 @@
+/**
+ * Button Components - Clean Weather Station UI
+ * 
+ * Modern, clean button system for weather data interfaces.
+ */
+
+// ==========================================================================
+// BASE BUTTON - CLEAN FOUNDATION
+// ==========================================================================
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 20px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.5;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.15s ease-in-out;
+  background: #ffffff;
+  color: #374151;
+  outline: none;
+  
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+  
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+  
+  &--small {
+    padding: 6px 12px;
+    font-size: 0.75rem;
+  }
+  
+  &--large {
+    padding: 12px 24px;
+    font-size: 1rem;
+  }
+  
+  &--block {
+    display: flex;
+    width: 100%;
+  }
+}
+
+// ==========================================================================
+// PRIMARY BUTTON - WEATHER BLUE
+// ==========================================================================
+
+.btn--primary {
+  background: #0ea5e9;
+  color: white;
+  border-color: #0ea5e9;
+  
+  &:hover:not(:disabled) {
+    background: #0284c7;
+    border-color: #0284c7;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(14, 165, 233, 0.3);
+  }
+  
+  &:active {
+    transform: translateY(0);
+  }
+}
+
+.btn--primary-outline {
+  background: transparent;
+  color: #0ea5e9;
+  border-color: #0ea5e9;
+  
+  &:hover:not(:disabled) {
+    background: #0ea5e9;
+    color: white;
+  }
+}
+
+// ==========================================================================
+// SECONDARY BUTTON - NEUTRAL GRAY
+// ==========================================================================
+
+.btn--secondary {
+  background: #f8fafc;
+  color: #475569;
+  border-color: #e2e8f0;
+  
+  &:hover:not(:disabled) {
+    background: #f1f5f9;
+    border-color: #cbd5e1;
+    transform: translateY(-1px);
+  }
+}
+
+// ==========================================================================
+// SUCCESS BUTTON - NATURE GREEN
+// ==========================================================================
+
+.btn--success {
+  background: #22c55e;
+  color: white;
+  border-color: #22c55e;
+  
+  &:hover:not(:disabled) {
+    background: #16a34a;
+    border-color: #16a34a;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(34, 197, 94, 0.3);
+  }
+}
+
+.btn--success-outline {
+  background: transparent;
+  color: #22c55e;
+  border-color: #22c55e;
+  
+  &:hover:not(:disabled) {
+    background: #22c55e;
+    color: white;
+  }
+}
+
+// ==========================================================================
+// WARNING BUTTON - WEATHER ALERT
+// ==========================================================================
+
+.btn--warning {
+  background: #f59e0b;
+  color: white;
+  border-color: #f59e0b;
+  
+  &:hover:not(:disabled) {
+    background: #d97706;
+    border-color: #d97706;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(245, 158, 11, 0.3);
+  }
+}
+
+.btn--warning-outline {
+  background: transparent;
+  color: #f59e0b;
+  border-color: #f59e0b;
+  
+  &:hover:not(:disabled) {
+    background: #f59e0b;
+    color: white;
+  }
+}
+
+// ==========================================================================
+// DANGER BUTTON - ERROR/DISCONNECT
+// ==========================================================================
+
+.btn--danger {
+  background: #ef4444;
+  color: white;
+  border-color: #ef4444;
+  
+  &:hover:not(:disabled) {
+    background: #dc2626;
+    border-color: #dc2626;
+    transform: translateY(-1px);
+    box-shadow: 0 4px 8px rgba(239, 68, 68, 0.3);
+  }
+}
+
+.btn--danger-outline {
+  background: transparent;
+  color: #ef4444;
+  border-color: #ef4444;
+  
+  &:hover:not(:disabled) {
+    background: #ef4444;
+    color: white;
+  }
+}
+
+// ==========================================================================
+// GHOST BUTTON - MINIMAL
+// ==========================================================================
+
+.btn--ghost {
+  background: transparent;
+  color: #6b7280;
+  border-color: transparent;
+  
+  &:hover:not(:disabled) {
+    background: #f9fafb;
+    color: #374151;
+  }
+}
+
+// ==========================================================================
+// LINK BUTTON - TEXT STYLE
+// ==========================================================================
+
+.btn--link {
+  background: transparent;
+  color: #0ea5e9;
+  border-color: transparent;
+  padding: 4px 8px;
+  text-decoration: none;
+  
+  &:hover:not(:disabled) {
+    color: #0284c7;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+}
+
+// ==========================================================================
+// BUTTON GROUPS
+// ==========================================================================
+
+.btn-group {
+  display: inline-flex;
+  
+  .btn {
+    border-radius: 0;
+    border-right-width: 0;
+    
+    &:first-child {
+      border-radius: 8px 0 0 8px;
+    }
+    
+    &:last-child {
+      border-radius: 0 8px 8px 0;
+      border-right-width: 1px;
+    }
+    
+    &:only-child {
+      border-radius: 8px;
+      border-right-width: 1px;
+    }
+  }
+}
+
+// ==========================================================================
+// LOADING STATE
+// ==========================================================================
+
+.btn--loading {
+  position: relative;
+  color: transparent;
+  pointer-events: none;
+  
+  &::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 16px;
+    height: 16px;
+    border: 2px solid transparent;
+    border-top: 2px solid currentColor;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: translate(-50%, -50%) rotate(0deg);
+  }
+  to {
+    transform: translate(-50%, -50%) rotate(360deg);
+  }
+}

--- a/assets/src/scss_OLD/components/_connections.scss
+++ b/assets/src/scss_OLD/components/_connections.scss
@@ -1,0 +1,356 @@
+/**
+ * Connections Component - SLEEK & PROFESSIONAL EDITION 🖤
+ * 
+ * Modern, minimalist design with sophisticated colors and clean animations.
+ */
+
+// ==========================================================================
+// CONNECTIONS CONTAINER - CLEAN & MODERN
+// ==========================================================================
+
+.ecowitt-admin {
+
+  .connections-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: $spacing-xl;
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.06);
+  }
+
+  .connections-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+    gap: $spacing-lg;
+    margin-bottom: $spacing-xl;
+  }
+
+  // ==========================================================================
+  // CONNECTION CARD - SOPHISTICATED CARDS
+  // ==========================================================================
+
+  .connection-card {
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    padding: $spacing-lg;
+    transition: all 0.2s ease;
+    position: relative;
+    
+    &::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 3px;
+      border-radius: 8px 8px 0 0;
+      background: #6b7280;
+    }
+    
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      border-color: #d1d5db;
+    }
+
+    &.connection--active {
+      &::before {
+        background: #10b981;
+      }
+      
+      .connection__status {
+        background: #d1fae5;
+        color: #047857;
+        border: 1px solid #a7f3d0;
+      }
+    }
+
+    &.connection--inactive {
+      &::before {
+        background: #f59e0b;
+      }
+      
+      .connection__status {
+        background: #fef3c7;
+        color: #92400e;
+        border: 1px solid #fde68a;
+      }
+    }
+
+    &.connection--editing {
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+      
+      &::before {
+        background: #3b82f6;
+      }
+    }
+  }
+
+  .connection__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: $spacing-md;
+    gap: $spacing-md;
+  }
+
+  .connection__title-group {
+    flex: 1;
+  }
+
+  .connection__title {
+    margin: 0 0 $spacing-xs 0;
+    color: #111827;
+    font-size: 1.25rem;
+    font-weight: 600;
+    line-height: 1.4;
+  }
+
+  .connection__status {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 12px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    border-radius: 20px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .connection__actions {
+    display: flex;
+    gap: $spacing-xs;
+  }
+
+  .connection__content {
+    margin-bottom: $spacing-md;
+    
+    .connection__description {
+      margin: 0 0 $spacing-md 0;
+      color: #6b7280;
+      font-style: italic;
+      padding: $spacing-sm;
+      background: #f9fafb;
+      border-radius: 6px;
+      border-left: 3px solid #e5e7eb;
+    }
+  }
+
+  .connection__details {
+    display: grid;
+    gap: $spacing-sm;
+  }
+
+  .connection__detail {
+    display: flex;
+    align-items: center;
+    gap: $spacing-sm;
+    padding: $spacing-xs;
+    
+    .detail__label {
+      min-width: 100px;
+      font-weight: 500;
+      color: #374151;
+      font-size: 0.875rem;
+    }
+    
+    .detail__value {
+      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+      background: #f3f4f6;
+      color: #1f2937;
+      padding: 4px 8px;
+      border-radius: 4px;
+      font-size: 0.875rem;
+      border: 1px solid #e5e7eb;
+      
+      &--masked {
+        background: #fee2e2;
+        color: #991b1b;
+        border-color: #fecaca;
+      }
+    }
+  }
+
+  .connection__footer {
+    margin-top: $spacing-md;
+    padding-top: $spacing-md;
+    border-top: 1px solid #f3f4f6;
+    
+    .connection__meta {
+      font-size: 0.875rem;
+      color: #6b7280;
+    }
+  }
+
+  // ==========================================================================
+  // NEW CONNECTION SECTION - CLEAN CALL-TO-ACTION
+  // ==========================================================================
+
+  .new-connection {
+    text-align: center;
+    padding: $spacing-xl;
+    border: 2px dashed #d1d5db;
+    border-radius: 8px;
+    background: #fafafa;
+    transition: all 0.2s ease;
+    
+    &:hover {
+      border-color: #3b82f6;
+      background: #f8faff;
+    }
+
+    .new-connection__icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 48px;
+      height: 48px;
+      background: #3b82f6;
+      border-radius: 8px;
+      margin-bottom: $spacing-md;
+      
+      svg {
+        color: white;
+      }
+    }
+
+    .new-connection__title {
+      margin: 0 0 $spacing-sm 0;
+      color: #111827;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+
+    .new-connection__description {
+      margin: 0 0 $spacing-lg 0;
+      color: #6b7280;
+      max-width: 400px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+  }
+
+  .new-connection-form {
+    margin-top: $spacing-lg;
+    padding: $spacing-xl;
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    
+    &.is-active {
+      animation: slideDown 0.3s ease;
+    }
+    
+    .form-header {
+      margin-bottom: $spacing-lg;
+      text-align: center;
+      
+      .form-title {
+        margin: 0 0 $spacing-sm 0;
+        color: #111827;
+        font-size: 1.5rem;
+        font-weight: 600;
+      }
+      
+      .form-description {
+        margin: 0;
+        color: #6b7280;
+      }
+    }
+  }
+
+  // ==========================================================================
+  // EMPTY STATE - ELEGANT PLACEHOLDER
+  // ==========================================================================
+
+  .connections-empty {
+    text-align: center;
+    padding: $spacing-xxl;
+    color: #6b7280;
+
+    .empty-icon {
+      margin-bottom: $spacing-lg;
+      opacity: 0.5;
+
+      svg {
+        color: #9ca3af;
+      }
+    }
+
+    .empty-title {
+      margin: 0 0 $spacing-sm 0;
+      color: #374151;
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+
+    .empty-description {
+      margin: 0;
+      max-width: 400px;
+      margin: 0 auto;
+      line-height: 1.6;
+    }
+  }
+
+  @keyframes slideDown {
+    from {
+      opacity: 0;
+      transform: translateY(-10px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+}
+// CONNECTIONS CONTAINER - MAGICAL GRADIENT PARADISE
+// ==========================================================================
+.ecowitt-admin {
+    .connections-container {
+        position: relative;
+        padding: $spacing-xxl;
+        margin-bottom: $spacing-xl;
+        background: linear-gradient(135deg, #667eea 0%, #764ba2 50%, #f093fb 100%);
+        border-radius: 24px;
+        box-shadow: 0 25px 50px rgba(102, 126, 234, 0.3);
+        overflow: hidden;
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(255, 255, 255, 0.95);
+            backdrop-filter: blur(10px);
+            z-index: 0;
+        }
+        >* {
+            position: relative;
+            z-index: 1;
+        }
+        &::after {
+            content: '🌤️⛈️🌈';
+            position: absolute;
+            top: $spacing-lg;
+            right: $spacing-lg;
+            font-size: 2rem;
+            opacity: 0.7;
+            animation: weather-float 4s ease-in-out infinite;
+            z-index: 1;
+        }
+    }
+    .connections-list {
+        display: grid;
+        gap: $spacing-xl;
+        margin-bottom: $spacing-xxl;
+        @include tablet-up {
+            grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+        }
+}
+        background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);

--- a/assets/src/scss_OLD/components/_forms.scss
+++ b/assets/src/scss_OLD/components/_forms.scss
@@ -1,0 +1,819 @@
+/**
+ * Form Components - Clean Weather Station UI
+ * 
+ * Professional form styling for weather data configuration.
+ */
+
+// ==========================================================================
+// FORM LAYOUTS
+// ==========================================================================
+
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-row {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  
+  .form-group {
+    flex: 1;
+    margin-bottom: 0;
+  }
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+// ==========================================================================
+// LABELS
+// ==========================================================================
+
+.form-label {
+  display: block;
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+  color: #374151;
+  font-size: 0.875rem;
+}
+
+.form-label--required {
+  &::after {
+    content: ' *';
+    color: #ef4444;
+  }
+}
+
+// ==========================================================================
+// INPUT FIELDS
+// ==========================================================================
+
+.form-input {
+  display: block;
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: #374151;
+  background: #ffffff;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+  
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+  
+  &:disabled {
+    background-color: #f9fafb;
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+  
+  &::placeholder {
+    color: #9ca3af;
+  }
+}
+
+.form-input--small {
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+}
+
+.form-input--large {
+  padding: 1rem 1.25rem;
+  font-size: 1rem;
+}
+
+// ==========================================================================
+// INPUT STATES
+// ==========================================================================
+
+.form-input--success {
+  border-color: #22c55e;
+  
+  &:focus {
+    border-color: #22c55e;
+    box-shadow: 0 0 0 3px rgba(34, 197, 94, 0.1);
+  }
+}
+
+.form-input--error {
+  border-color: #ef4444;
+  
+  &:focus {
+    border-color: #ef4444;
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.1);
+  }
+}
+
+.form-input--warning {
+  border-color: #f59e0b;
+  
+  &:focus {
+    border-color: #f59e0b;
+    box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.1);
+  }
+}
+
+// ==========================================================================
+// TEXTAREA
+// ==========================================================================
+
+.form-textarea {
+  @extend .form-input;
+  resize: vertical;
+  min-height: 100px;
+}
+
+// ==========================================================================
+// SELECT
+// ==========================================================================
+
+.form-select {
+  @extend .form-input;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3E%3Cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3E%3C/svg%3E");
+  background-position: right 0.5rem center;
+  background-repeat: no-repeat;
+  background-size: 1.5em 1.5em;
+  padding-right: 2.5rem;
+  appearance: none;
+}
+
+// ==========================================================================
+// CHECKBOX & RADIO
+// ==========================================================================
+
+.form-checkbox,
+.form-radio {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid #d1d5db;
+  background: #ffffff;
+  transition: all 0.15s ease-in-out;
+  
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+  
+  &:checked {
+    border-color: #3b82f6;
+    background-color: #3b82f6;
+  }
+}
+
+.form-checkbox {
+  border-radius: 0.25rem;
+  
+  &:checked {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M12.207 4.793a1 1 0 0 1 0 1.414l-5 5a1 1 0 0 1-1.414 0l-2-2a1 1 0 0 1 1.414-1.414L6.5 9.086l4.293-4.293a1 1 0 0 1 1.414 0z'/%3E%3C/svg%3E");
+  }
+}
+
+.form-radio {
+  border-radius: 50%;
+  
+  &:checked {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='8' cy='8' r='3'/%3E%3C/svg%3E");
+  }
+}
+
+// ==========================================================================
+// CHECKBOX & RADIO LABELS
+// ==========================================================================
+
+.form-check {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  
+  .form-check-input {
+    flex-shrink: 0;
+  }
+  
+  .form-check-label {
+    margin-bottom: 0;
+    font-weight: 400;
+    cursor: pointer;
+  }
+}
+
+// ==========================================================================
+// HELP TEXT
+// ==========================================================================
+
+.form-help {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: #6b7280;
+  line-height: 1.4;
+}
+
+.form-help--success {
+  color: #22c55e;
+}
+
+.form-help--error {
+  color: #ef4444;
+}
+
+.form-help--warning {
+  color: #f59e0b;
+}
+
+// ==========================================================================
+// INPUT GROUPS
+// ==========================================================================
+
+.input-group {
+  display: flex;
+  
+  .form-input {
+    border-radius: 0;
+    
+    &:first-child {
+      border-radius: 6px 0 0 6px;
+    }
+    
+    &:last-child {
+      border-radius: 0 6px 6px 0;
+      border-left-width: 0;
+    }
+    
+    &:only-child {
+      border-radius: 6px;
+    }
+    
+    &:not(:first-child):not(:last-child) {
+      border-left-width: 0;
+      border-right-width: 0;
+    }
+  }
+}
+
+.input-group-text {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #6b7280;
+  text-align: center;
+  white-space: nowrap;
+  background-color: #f9fafb;
+  border: 1px solid #d1d5db;
+  
+  &:first-child {
+    border-radius: 6px 0 0 6px;
+    border-right: 0;
+  }
+  
+  &:last-child {
+    border-radius: 0 6px 6px 0;
+    border-left: 0;
+  }
+}
+
+// ==========================================================================
+// FORM VALIDATION
+// ==========================================================================
+
+.form-error {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: #ef4444;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  
+  &::before {
+    content: '⚠';
+    font-size: 0.875rem;
+  }
+}
+
+.form-success {
+  margin-top: 0.25rem;
+  font-size: 0.75rem;
+  color: #22c55e;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  
+  &::before {
+    content: '✓';
+    font-size: 0.875rem;
+  }
+}
+
+// ==========================================================================
+// FIELDSETS
+// ==========================================================================
+
+.form-fieldset {
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1.5rem;
+  margin-bottom: 1.5rem;
+  
+  .form-legend {
+    font-weight: 600;
+    color: #374151;
+    font-size: 1rem;
+    margin-bottom: 1rem;
+    padding: 0 0.5rem;
+    background: #ffffff;
+  }
+}
+
+// ==========================================================================
+// FORM SECTIONS
+// ==========================================================================
+
+.form-section {
+  margin-bottom: 2rem;
+  
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.form-section-header {
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid #e5e7eb;
+  
+  .form-section-title {
+    margin: 0 0 0.25rem 0;
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: #111827;
+  }
+  
+  .form-section-description {
+    margin: 0;
+    font-size: 0.875rem;
+    color: #6b7280;
+    line-height: 1.5;
+  }
+}
+// FORM FOUNDATIONS - GORGEOUS BASICS! 🌟
+// ==========================================================================
+.ecowitt-admin {
+    .form-group {
+        position: relative;
+        margin-bottom: $spacing-lg;
+        &.form-group--floating {
+            .form-control {
+                padding-top: 20px;
+                padding-bottom: 8px;
+                &:focus~.form-label,
+                &:not(:placeholder-shown)~.form-label {
+                    transform: translateY(-12px) scale(0.85);
+                    color: #667eea;
+                }
+            }
+            .form-label {
+                position: absolute;
+                top: 16px;
+                left: 16px;
+                transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+                pointer-events: none;
+                z-index: 2;
+                background: white;
+                padding: 0 4px;
+                margin: 0;
+            }
+        }
+    }
+    // ==========================================================================
+    // LABELS - BEAUTIFUL TYPOGRAPHY! 📝
+    // ==========================================================================
+    .form-label {
+        display: block;
+        margin-bottom: 8px;
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: #334155;
+        position: relative;
+        // Required indicator with style!
+        &.form-label--required::after {
+            content: '*';
+            color: #ef4444;
+            margin-left: 4px;
+            font-size: 1.1rem;
+            animation: required-pulse 2s infinite;
+        }
+        // Optional indicator
+        &.form-label--optional::after {
+            content: '(optional)';
+            color: #64748b;
+            margin-left: 6px;
+            font-size: 0.8rem;
+            font-weight: 400;
+            font-style: italic;
+        }
+        // Icon support
+        &.form-label--icon {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            svg {
+                width: 16px;
+                height: 16px;
+                color: #667eea;
+            }
+        }
+    }
+    // ==========================================================================
+    // FORM CONTROLS - STUNNING INPUTS! 🎯
+    // ==========================================================================
+    .form-control {
+        width: 100%;
+        padding: 14px 16px;
+        font-size: 0.95rem;
+        line-height: 1.5;
+        color: #1e293b;
+        background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+        border: 2px solid #e2e8f0;
+        border-radius: 12px;
+        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        position: relative;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+        &::placeholder {
+            color: #94a3b8;
+            transition: opacity 0.3s ease;
+        }
+        &:hover {
+            border-color: #cbd5e1;
+            background: linear-gradient(135deg, #ffffff 0%, #f1f5f9 100%);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+        }
+        &:focus {
+            outline: none;
+            border-color: #667eea;
+            background: white;
+            box-shadow: 0 0 0 4px rgba(102, 126, 234, 0.1), 0 8px 20px rgba(102, 126, 234, 0.15);
+            transform: scale(1.02);
+            &::placeholder {
+                opacity: 0.7;
+            }
+        }
+        // Input states with vibrant colors!
+        &.form-control--success {
+            border-color: #10b981;
+            background: linear-gradient(135deg, #ffffff 0%, #f0fdf4 100%);
+            &:focus {
+                border-color: #059669;
+                box-shadow: 0 0 0 4px rgba(16, 185, 129, 0.15), 0 8px 20px rgba(16, 185, 129, 0.2);
+            }
+        }
+        &.form-control--error {
+            border-color: #ef4444;
+            background: linear-gradient(135deg, #ffffff 0%, #fef2f2 100%);
+            animation: shake 0.5s ease-in-out;
+            &:focus {
+                border-color: #dc2626;
+                box-shadow: 0 0 0 4px rgba(239, 68, 68, 0.15), 0 8px 20px rgba(239, 68, 68, 0.2);
+            }
+        }
+        &.form-control--warning {
+            border-color: #f59e0b;
+            background: linear-gradient(135deg, #ffffff 0%, #fffbeb 100%);
+            &:focus {
+                border-color: #d97706;
+                box-shadow: 0 0 0 4px rgba(245, 158, 11, 0.15), 0 8px 20px rgba(245, 158, 11, 0.2);
+            }
+        }
+        // Special input types
+        &[type="password"] {
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+            letter-spacing: 2px;
+        }
+        &[type="email"] {
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+        }
+    }
+    // ==========================================================================
+    // TEXTAREAS - EXPANDABLE BEAUTY! 📝
+    // ==========================================================================
+    textarea.form-control {
+        min-height: 120px;
+        resize: vertical;
+        padding: 16px;
+        line-height: 1.6;
+        &:focus {
+            transform: none; // Don't scale textareas
+        }
+    }
+    // ==========================================================================
+    // SELECT DROPDOWNS - STYLISH CHOICES! 🎨
+    // ==========================================================================
+    .form-select {
+        @extend .form-control;
+        cursor: pointer;
+        background-image: linear-gradient(45deg, transparent 50%, #667eea 50%), linear-gradient(135deg, #667eea 50%, transparent 50%);
+        background-position: calc(100% - 20px) calc(1em + 2px), calc(100% - 15px) calc(1em + 2px);
+        background-size: 5px 5px, 5px 5px;
+        background-repeat: no-repeat;
+        padding-right: 45px;
+        &:hover {
+            background-image: linear-gradient(45deg, transparent 50%, #5a6fd8 50%), linear-gradient(135deg, #5a6fd8 50%, transparent 50%);
+        }
+        &:focus {
+            background-image: linear-gradient(45deg, transparent 50%, #4e5bc6 50%), linear-gradient(135deg, #4e5bc6 50%, transparent 50%);
+        }
+    }
+    // ==========================================================================
+    // FORM GRID - ORGANIZED LAYOUTS! 📐
+    // ==========================================================================
+    .form-grid {
+        display: grid;
+        gap: $spacing-lg;
+        &.form-grid--2-col {
+            @include tablet-up {
+                grid-template-columns: repeat(2, 1fr);
+            }
+        }
+        &.form-grid--3-col {
+            @include tablet-up {
+                grid-template-columns: repeat(2, 1fr);
+            }
+            @include desktop-up {
+                grid-template-columns: repeat(3, 1fr);
+            }
+        }
+        &.form-grid--auto {
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+        }
+        // Responsive single column override
+        &.form-grid--single {
+            grid-template-columns: 1fr;
+        }
+    }
+    // ==========================================================================
+    // FORM HELP TEXT - HELPFUL GUIDANCE! 💡
+    // ==========================================================================
+    .form-help {
+        display: flex;
+        align-items: flex-start;
+        gap: 8px;
+        margin-top: 8px;
+        font-size: 0.85rem;
+        line-height: 1.5;
+        color: #64748b;
+        padding: 8px 12px;
+        background: rgba(102, 126, 234, 0.05);
+        border-radius: 8px;
+        border-left: 3px solid #667eea;
+        &::before {
+            content: 'ℹ️';
+            font-size: 0.9rem;
+            margin-top: 2px;
+            flex-shrink: 0;
+        }
+        &.form-help--success {
+            color: #047857;
+            background: rgba(16, 185, 129, 0.05);
+            border-left-color: #10b981;
+            &::before {
+                content: '✅';
+            }
+        }
+        &.form-help--error {
+            color: #b91c1c;
+            background: rgba(239, 68, 68, 0.05);
+            border-left-color: #ef4444;
+            &::before {
+                content: '❌';
+            }
+        }
+        &.form-help--warning {
+            color: #92400e;
+            background: rgba(245, 158, 11, 0.05);
+            border-left-color: #f59e0b;
+            &::before {
+                content: '⚠️';
+            }
+        }
+    }
+    // ==========================================================================
+    // FORM ACTIONS - ORGANIZED BUTTONS! 🎯
+    // ==========================================================================
+    .form-actions {
+        display: flex;
+        align-items: center;
+        gap: $spacing-md;
+        margin-top: $spacing-xl;
+        padding-top: $spacing-lg;
+        border-top: 2px dashed rgba(102, 126, 234, 0.2);
+        position: relative;
+        &::before {
+            content: '';
+            position: absolute;
+            top: -1px;
+            left: 0;
+            right: 0;
+            height: 2px;
+            background: linear-gradient(90deg, transparent, #667eea, transparent);
+            opacity: 0.3;
+        }
+        .ml-auto {
+            margin-left: auto;
+        }
+        @include mobile-only {
+            flex-direction: column;
+            .btn {
+                width: 100%;
+            }
+            .ml-auto {
+                margin-left: 0;
+                order: -1;
+            }
+        }
+    }
+    // ==========================================================================
+    // INPUT GROUPS - COMBINED CONTROLS! 🔗
+    // ==========================================================================
+    .input-group {
+        display: flex;
+        border-radius: 12px;
+        overflow: hidden;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+        .form-control {
+            border-radius: 0;
+            border-right: none;
+            box-shadow: none;
+            &:focus {
+                transform: none;
+                z-index: 2;
+                position: relative;
+            }
+            &:first-child {
+                border-radius: 12px 0 0 12px;
+            }
+            &:last-child {
+                border-radius: 0 12px 12px 0;
+                border-right: 2px solid #e2e8f0;
+            }
+        }
+        .input-group-text {
+            display: flex;
+            align-items: center;
+            padding: 14px 16px;
+            background: linear-gradient(135deg, #f8fafc, #e2e8f0);
+            border: 2px solid #e2e8f0;
+            border-right: none;
+            color: #64748b;
+            font-weight: 500;
+            &:last-child {
+                border-right: 2px solid #e2e8f0;
+                border-left: none;
+            }
+            svg {
+                width: 16px;
+                height: 16px;
+                color: #667eea;
+            }
+        }
+    }
+    // ==========================================================================
+    // CHECKBOXES & RADIOS - BEAUTIFUL CHOICES! ✨
+    // ==========================================================================
+    .form-check {
+        display: flex;
+        align-items: flex-start;
+        gap: 12px;
+        margin-bottom: $spacing-md;
+        padding: 12px;
+        border-radius: 12px;
+        transition: all 0.3s ease;
+        &:hover {
+            background: rgba(102, 126, 234, 0.05);
+        }
+        .form-check-input {
+            margin: 0;
+            width: 20px;
+            height: 20px;
+            border: 2px solid #cbd5e1;
+            border-radius: 6px;
+            background: white;
+            transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+            position: relative;
+            cursor: pointer;
+            &:checked {
+                background: linear-gradient(135deg, #667eea, #764ba2);
+                border-color: #667eea;
+                &::after {
+                    content: '✓';
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    transform: translate(-50%, -50%);
+                    color: white;
+                    font-size: 12px;
+                    font-weight: bold;
+                }
+            }
+            &:focus {
+                outline: none;
+                box-shadow: 0 0 0 4px rgba(102, 126, 234, 0.2);
+            }
+            &[type="radio"] {
+                border-radius: 50%;
+                &:checked::after {
+                    content: '';
+                    width: 8px;
+                    height: 8px;
+                    background: white;
+                    border-radius: 50%;
+                }
+            }
+        }
+        .form-check-label {
+            flex: 1;
+            cursor: pointer;
+            line-height: 1.5;
+            color: #334155;
+            font-weight: 500;
+        }
+    }
+    // ==========================================================================
+    // STUNNING ANIMATIONS! 🎬
+    // ==========================================================================
+    @keyframes required-pulse {
+        0%,
+        100% {
+            opacity: 1;
+            transform: scale(1);
+        }
+        50% {
+            opacity: 0.7;
+            transform: scale(1.1);
+        }
+    }
+    @keyframes shake {
+        0%,
+        100% {
+            transform: translateX(0);
+        }
+        25% {
+            transform: translateX(-4px);
+        }
+        75% {
+            transform: translateX(4px);
+        }
+    }
+    // ==========================================================================
+    // LOADING OVERLAYS! ⚡
+    // ==========================================================================
+    .form-loading {
+        position: relative;
+        &::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(255, 255, 255, 0.8);
+            backdrop-filter: blur(2px);
+            z-index: 10;
+            border-radius: inherit;
+        }
+        &::after {
+            content: '';
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 32px;
+            height: 32px;
+            margin: -16px 0 0 -16px;
+            border: 3px solid #e2e8f0;
+            border-top: 3px solid #667eea;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            z-index: 11;
+        }
+    }
+    @keyframes spin {
+        from {
+            transform: rotate(0deg);
+        }
+        to {
+            transform: rotate(360deg);
+        }
+    }
+}

--- a/assets/src/scss_OLD/components/_notifications.scss
+++ b/assets/src/scss_OLD/components/_notifications.scss
@@ -1,0 +1,296 @@
+/**
+ * Notifications
+ * 
+ * Admin notification styles that integrate with WordPress notices
+ * while providing enhanced styling and animations.
+ */
+
+// ==========================================================================
+// BASE NOTIFICATION STYLES
+// ==========================================================================
+.ecowitt-admin {
+    .notification {
+        display: flex;
+        align-items: flex-start;
+        gap: $spacing-sm;
+        padding: $spacing-md;
+        margin-bottom: $spacing-md;
+        border-radius: $border-radius-md;
+        border-left: 4px solid;
+        background-color: $white;
+        box-shadow: $shadow-sm;
+        transition: all $transition-normal $easing-ease;
+        position: relative;
+        @include fade-in;
+        &:last-child {
+            margin-bottom: 0;
+        }
+        // Dismissible notifications
+        &.is-dismissible {
+            padding-right: spacing(5);
+        }
+        // Notification icon
+        .notification__icon {
+            flex-shrink: 0;
+            width: 20px;
+            height: 20px;
+            margin-top: 2px;
+        }
+        // Notification content
+        .notification__content {
+            flex: 1;
+            min-width: 0;
+        }
+        .notification__title {
+            font-weight: $font-weight-semibold;
+            margin-bottom: spacing(0.5);
+            color: inherit;
+        }
+        .notification__message {
+            font-size: $font-size-sm;
+            line-height: $line-height-relaxed;
+            margin: 0;
+            p {
+                margin-bottom: spacing(0.5);
+                &:last-child {
+                    margin-bottom: 0;
+                }
+            }
+            a {
+                color: inherit;
+                text-decoration: underline;
+                font-weight: $font-weight-medium;
+                &:hover {
+                    text-decoration: none;
+                }
+            }
+        }
+        // Dismiss button
+        .notification__dismiss {
+            position: absolute;
+            top: $spacing-sm;
+            right: $spacing-sm;
+            width: 24px;
+            height: 24px;
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: inherit;
+            opacity: 0.6;
+            transition: opacity $transition-fast $easing-ease;
+            &:hover,
+            &:focus {
+                opacity: 1;
+            }
+            &:focus {
+                outline: 2px solid currentColor;
+                outline-offset: 2px;
+                border-radius: $border-radius-sm;
+            }
+            svg {
+                width: 16px;
+                height: 16px;
+            }
+        }
+    }
+    // ==========================================================================
+    // NOTIFICATION VARIANTS
+    // ==========================================================================
+    .notification--success {
+        border-left-color: $wp-success;
+        background-color: alpha-color($wp-success, 0.05);
+        color: darken($wp-success, 25%);
+        .notification__icon {
+            color: $wp-success;
+        }
+    }
+    .notification--error {
+        border-left-color: $wp-error;
+        background-color: alpha-color($wp-error, 0.05);
+        color: darken($wp-error, 15%);
+        .notification__icon {
+            color: $wp-error;
+        }
+    }
+    .notification--warning {
+        border-left-color: $wp-warning;
+        background-color: alpha-color($wp-warning, 0.05);
+        color: darken($wp-warning, 25%);
+        .notification__icon {
+            color: $wp-warning;
+        }
+    }
+    .notification--info {
+        border-left-color: $wp-info;
+        background-color: alpha-color($wp-info, 0.05);
+        color: darken($wp-info, 25%);
+        .notification__icon {
+            color: $wp-info;
+        }
+    }
+    // ==========================================================================
+    // NOTIFICATION SIZES
+    // ==========================================================================
+    .notification--sm {
+        padding: $spacing-sm;
+        font-size: $font-size-xs;
+        .notification__icon {
+            width: 16px;
+            height: 16px;
+        }
+        .notification__dismiss {
+            width: 20px;
+            height: 20px;
+            top: spacing(0.5);
+            right: spacing(0.5);
+            svg {
+                width: 12px;
+                height: 12px;
+            }
+        }
+    }
+    .notification--lg {
+        padding: $spacing-lg;
+        .notification__title {
+            font-size: $font-size-md;
+            margin-bottom: $spacing-sm;
+        }
+        .notification__message {
+            font-size: $font-size-base;
+        }
+        .notification__icon {
+            width: 24px;
+            height: 24px;
+        }
+    }
+    // ==========================================================================
+    // WORDPRESS NOTICE INTEGRATION
+    // ==========================================================================
+    // Override WordPress notices within our admin
+    .notice {
+        border-left: 4px solid;
+        padding: $spacing-md;
+        margin: $spacing-md 0;
+        background-color: $white;
+        box-shadow: $shadow-sm;
+        border-radius: $border-radius-md;
+        &.notice-success {
+            @extend .notification--success;
+        }
+        &.notice-error {
+            @extend .notification--error;
+        }
+        &.notice-warning {
+            @extend .notification--warning;
+        }
+        &.notice-info {
+            @extend .notification--info;
+        }
+        p {
+            margin: spacing(0.5) 0;
+            font-size: $font-size-sm;
+            line-height: $line-height-relaxed;
+            &:first-child {
+                margin-top: 0;
+            }
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+        .notice-dismiss {
+            position: absolute;
+            top: 0;
+            right: 1px;
+            width: 24px;
+            height: 24px;
+            background: none;
+            border: none;
+            cursor: pointer;
+            color: inherit;
+            opacity: 0.6;
+            transition: opacity $transition-fast $easing-ease;
+            &:hover,
+            &:focus {
+                opacity: 1;
+            }
+            &:focus {
+                outline: 2px solid currentColor;
+                outline-offset: 2px;
+                border-radius: $border-radius-sm;
+            }
+            &::before {
+                content: '×';
+                font-size: 18px;
+                line-height: 1;
+            }
+        }
+    }
+    // ==========================================================================
+    // NOTIFICATION GROUPS
+    // ==========================================================================
+    .notifications {
+        margin-bottom: $spacing-lg;
+        .notification {
+            margin-bottom: $spacing-sm;
+            &:last-child {
+                margin-bottom: 0;
+            }
+        }
+    }
+    .notifications--stacked {
+        .notification {
+            border-radius: 0;
+            margin-bottom: 0;
+            border-bottom: 1px solid alpha-color($gray-300, 0.5);
+            &:first-child {
+                border-top-left-radius: $border-radius-md;
+                border-top-right-radius: $border-radius-md;
+            }
+            &:last-child {
+                border-bottom-left-radius: $border-radius-md;
+                border-bottom-right-radius: $border-radius-md;
+                border-bottom: none;
+            }
+        }
+    }
+    // ==========================================================================
+    // NOTIFICATION ANIMATIONS
+    // ==========================================================================
+    .notification--slide-in {
+        @include slide-in-top;
+    }
+    .notification--fade-out {
+        opacity: 0;
+        transform: translateY(-10px);
+        transition: all $transition-normal $easing-ease-in;
+    }
+    // ==========================================================================
+    // INLINE NOTIFICATIONS
+    // ==========================================================================
+    .notification--inline {
+        margin: $spacing-sm 0;
+        padding: $spacing-sm;
+        border-radius: $border-radius-sm;
+        box-shadow: none;
+        border: 1px solid;
+        &.notification--success {
+            border-color: alpha-color($wp-success, 0.3);
+        }
+        &.notification--error {
+            border-color: alpha-color($wp-error, 0.3);
+        }
+        &.notification--warning {
+            border-color: alpha-color($wp-warning, 0.3);
+        }
+        &.notification--info {
+            border-color: alpha-color($wp-info, 0.3);
+        }
+        .notification__message {
+            font-size: $font-size-xs;
+        }
+        .notification__icon {
+            width: 16px;
+            height: 16px;
+        }
+    }
+}

--- a/assets/src/scss_OLD/layout/_admin-page.scss
+++ b/assets/src/scss_OLD/layout/_admin-page.scss
@@ -1,0 +1,250 @@
+/**
+ * Admin Page Layout
+ * 
+ * Base layout styles for WordPress admin pages.
+ * Provides consistent structure and spacing.
+ */
+
+// ==========================================================================
+// ADMIN PAGE WRAPPER
+// ==========================================================================
+.ecowitt-admin {
+    // Main admin page container
+    &.wrap {
+        margin: $spacing-lg $spacing-md 0 0;
+        @include tablet-up {
+            margin-right: $spacing-lg;
+        }
+    }
+    // Page header
+    .page-header {
+        // margin-bottom: $spacing-xl;
+        // padding-bottom: $spacing-lg;
+        // border-bottom: 1px solid $gray-200;
+        .page-title {
+            margin: 0 0 $spacing-sm 0;
+            font-size: $font-size-xxl;
+            font-weight: $font-weight-bold;
+            color: $gray-800;
+            line-height: $line-height-tight;
+        }
+        .page-subtitle {
+            margin: 0 0 $spacing-md 0;
+            font-size: $font-size-md;
+            color: $gray-600;
+            line-height: $line-height-relaxed;
+        }
+        .page-actions {
+            display: flex;
+            gap: $spacing-sm;
+            margin-top: $spacing-md;
+            @include tablet-up {
+                margin-top: 0;
+                align-items: center;
+            }
+        }
+        // Header with actions
+        &.page-header--with-actions {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            flex-wrap: wrap;
+            gap: $spacing-md;
+            .page-info {
+                flex: 1;
+                min-width: 300px;
+            }
+            .page-actions {
+                margin-top: 0;
+                flex-shrink: 0;
+            }
+        }
+    }
+    // ==========================================================================
+    // CONTENT AREAS
+    // ==========================================================================
+    .page-content {
+        margin-bottom: $spacing-xl;
+        // Content sections
+        .content-section {
+            margin-bottom: $spacing-xxxl;
+            &:last-child {
+                margin-bottom: 0;
+            }
+            .section-header {
+                margin-bottom: $spacing-lg;
+                .section-title {
+                    margin: 0 0 spacing(0.5) 0;
+                    font-size: $font-size-lg;
+                    font-weight: $font-weight-semibold;
+                    color: $gray-800;
+                }
+                .section-description {
+                    margin: 0;
+                    font-size: $font-size-sm;
+                    color: $gray-600;
+                    line-height: $line-height-relaxed;
+                }
+            }
+            // Content styles handled by individual components
+        }
+    }
+    // ==========================================================================
+    // GRID LAYOUTS
+    // ==========================================================================
+    .admin-grid {
+        display: grid;
+        gap: $spacing-lg;
+        &.admin-grid--2-col {
+            @include tablet-up {
+                grid-template-columns: 1fr 300px;
+            }
+        }
+        &.admin-grid--3-col {
+            @include desktop-up {
+                grid-template-columns: repeat(3, 1fr);
+            }
+        }
+        &.admin-grid--auto {
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+        }
+    }
+    // ==========================================================================
+    // SIDEBAR
+    // ==========================================================================
+    .admin-sidebar {
+        .sidebar-section {
+            @include card-base;
+            @include card-padding('md');
+            margin-bottom: $spacing-lg;
+            &:last-child {
+                margin-bottom: 0;
+            }
+            .sidebar-title {
+                margin: 0 0 $spacing-md 0;
+                font-size: $font-size-md;
+                font-weight: $font-weight-semibold;
+                color: $gray-800;
+            }
+            .sidebar-content {
+                font-size: $font-size-sm;
+                line-height: $line-height-relaxed;
+                color: $gray-600;
+                ul {
+                    margin: 0;
+                    padding-left: $spacing-md;
+                    li {
+                        margin-bottom: spacing(0.5);
+                        &:last-child {
+                            margin-bottom: 0;
+                        }
+                    }
+                }
+                .btn {
+                    width: 100%;
+                    margin-top: $spacing-sm;
+                }
+            }
+        }
+    }
+    // ==========================================================================
+    // RESPONSIVE UTILITIES
+    // ==========================================================================
+    // Show/hide on different screen sizes
+    .show-mobile {
+        @include tablet-up {
+            display: none !important;
+        }
+    }
+    .show-tablet {
+        display: none !important;
+        @include tablet-up {
+            display: block !important;
+        }
+        @include desktop-up {
+            display: none !important;
+        }
+    }
+    .show-desktop {
+        display: none !important;
+        @include desktop-up {
+            display: block !important;
+        }
+    }
+    .hide-mobile {
+        @include tablet-up {
+            display: block !important;
+        }
+    }
+    .hide-tablet {
+        @include tablet-up {
+            display: none !important;
+        }
+        @include desktop-up {
+            display: block !important;
+        }
+    }
+    .hide-desktop {
+        @include desktop-up {
+            display: none !important;
+        }
+    }
+    // ==========================================================================
+    // LOADING STATES
+    // ==========================================================================
+    .page-loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 200px;
+        color: $gray-500;
+        .loading-spinner {
+            width: 32px;
+            height: 32px;
+            border: 3px solid $gray-200;
+            border-top-color: $wp-admin-blue;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin-right: $spacing-md;
+        }
+        .loading-text {
+            font-size: $font-size-sm;
+        }
+    }
+    @keyframes spin {
+        to {
+            transform: rotate(360deg);
+        }
+    }
+    // ==========================================================================
+    // ERROR STATES
+    // ==========================================================================
+    .page-error {
+        text-align: center;
+        padding: $spacing-xxxl $spacing-lg;
+        .error-icon {
+            width: 64px;
+            height: 64px;
+            margin: 0 auto $spacing-lg;
+            color: $wp-error;
+            opacity: 0.6;
+        }
+        .error-title {
+            font-size: $font-size-lg;
+            font-weight: $font-weight-semibold;
+            color: $gray-800;
+            margin-bottom: $spacing-sm;
+        }
+        .error-message {
+            color: $gray-600;
+            margin-bottom: $spacing-lg;
+            line-height: $line-height-relaxed;
+        }
+        .error-actions {
+            display: flex;
+            gap: $spacing-sm;
+            justify-content: center;
+            flex-wrap: wrap;
+        }
+    }
+}

--- a/assets/src/scss_OLD/layout/_settings-page.scss
+++ b/assets/src/scss_OLD/layout/_settings-page.scss
@@ -1,0 +1,285 @@
+/**
+ * Settings Page Layout
+ * 
+ * Specific layout styles for the settings page.
+ * Handles the settings form structure and organization.
+ */
+
+// ==========================================================================
+// SETTINGS PAGE WRAPPER
+// ==========================================================================
+.ecowitt-admin {
+    .settings-page {
+        max-width: 1200px;
+    }
+    // ==========================================================================
+    // SETTINGS TABS (if needed in future)
+    // ==========================================================================
+    .settings-tabs {
+        margin-bottom: $spacing-xl;
+        border-bottom: 1px solid $gray-200;
+        .tabs-nav {
+            display: flex;
+            gap: 0;
+            margin: 0;
+            padding: 0;
+            list-style: none;
+            .tab-item {
+                .tab-link {
+                    display: block;
+                    padding: $spacing-md $spacing-lg;
+                    color: $gray-600;
+                    text-decoration: none;
+                    border-bottom: 3px solid transparent;
+                    transition: all $transition-fast $easing-ease;
+                    font-weight: $font-weight-medium;
+                    &:hover {
+                        color: $gray-800;
+                        background-color: $gray-50;
+                    }
+                    &.is-active {
+                        color: $wp-admin-blue;
+                        border-bottom-color: $wp-admin-blue;
+                        background-color: $white;
+                    }
+                }
+            }
+        }
+        .tab-content {
+            padding-top: $spacing-xl;
+        }
+    }
+    // ==========================================================================
+    // SETTINGS SECTIONS
+    // ==========================================================================
+    .settings-section {
+        @include card-base;
+        @include card-padding('xl');
+        margin-bottom: $spacing-xl;
+        &:last-child {
+            margin-bottom: 0;
+        }
+        .settings-section__header {
+            display: flex;
+            align-items: flex-start;
+            justify-content: space-between;
+            margin-bottom: $spacing-lg;
+            padding-bottom: $spacing-md;
+            border-bottom: 1px solid $gray-200;
+            gap: $spacing-md;
+            .section-info {
+                flex: 1;
+            }
+            .section-title {
+                margin: 0 0 spacing(0.5) 0;
+                font-size: $font-size-lg;
+                font-weight: $font-weight-semibold;
+                color: $gray-800;
+            }
+            .section-description {
+                margin: 0;
+                font-size: $font-size-sm;
+                color: $gray-600;
+                line-height: $line-height-relaxed;
+            }
+            .section-actions {
+                display: flex;
+                gap: spacing(0.5);
+                flex-shrink: 0;
+            }
+        }
+        // Content handled by components
+        // Section variants
+        &.settings-section--highlighted {
+            border-left: 4px solid $wp-admin-blue;
+            background-color: alpha-color($wp-admin-blue, 0.02);
+        }
+        &.settings-section--warning {
+            border-left: 4px solid $wp-warning;
+            background-color: alpha-color($wp-warning, 0.02);
+        }
+        &.settings-section--danger {
+            border-left: 4px solid $wp-error;
+            background-color: alpha-color($wp-error, 0.02);
+        }
+    }
+    // ==========================================================================
+    // SETTINGS FORM LAYOUT
+    // ==========================================================================
+    .settings-form {
+        .form-section {
+            margin-bottom: $spacing-xxxl;
+            &:last-child {
+                margin-bottom: 0;
+            }
+            .form-section__header {
+                margin-bottom: $spacing-lg;
+                .section-title {
+                    margin: 0 0 spacing(0.5) 0;
+                    font-size: $font-size-md;
+                    font-weight: $font-weight-medium;
+                    color: $gray-800;
+                }
+                .section-help {
+                    margin: 0;
+                    font-size: $font-size-sm;
+                    color: $gray-600;
+                    line-height: $line-height-relaxed;
+                }
+            }
+        }
+        // Two-column layout for larger screens
+        .form-row--columns {
+            @include tablet-up {
+                display: grid;
+                grid-template-columns: 200px 1fr;
+                gap: $spacing-lg;
+                align-items: start;
+                .form-label {
+                    margin-bottom: 0;
+                    padding-top: spacing(1);
+                }
+                .form-control-wrapper {
+                    .form-control {
+                        max-width: 400px;
+                    }
+                }
+            }
+        }
+    }
+    // ==========================================================================
+    // SETTINGS STATUS BAR
+    // ==========================================================================
+    .settings-status {
+        position: sticky;
+        top: 32px; // WordPress admin bar height
+        background-color: $white;
+        border: 1px solid $gray-200;
+        border-radius: $border-radius-lg;
+        padding: $spacing-md $spacing-lg;
+        margin-bottom: $spacing-lg;
+        box-shadow: $shadow-sm;
+        z-index: $z-sticky;
+        .status-content {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: $spacing-md;
+        }
+        .status-info {
+            display: flex;
+            align-items: center;
+            gap: $spacing-sm;
+            font-size: $font-size-sm;
+            .status-icon {
+                width: 16px;
+                height: 16px;
+            }
+            &.status--saved {
+                color: $wp-success;
+            }
+            &.status--unsaved {
+                color: $wp-warning;
+            }
+            &.status--error {
+                color: $wp-error;
+            }
+        }
+        .status-actions {
+            display: flex;
+            gap: spacing(0.5);
+        }
+    }
+    // ==========================================================================
+    // SETTINGS SIDEBAR
+    // ==========================================================================
+    .settings-layout {
+        @include desktop-up {
+            display: grid;
+            grid-template-columns: 1fr 300px;
+            gap: $spacing-xl;
+            align-items: start;
+        }
+    }
+    .settings-sidebar {
+        @include desktop-up {
+            position: sticky;
+            top: 100px; // Account for admin bar and status bar
+        }
+        .sidebar-widget {
+            @include card-base;
+            @include card-padding('md');
+            margin-bottom: $spacing-lg;
+            &:last-child {
+                margin-bottom: 0;
+            }
+            .widget-title {
+                margin: 0 0 $spacing-md 0;
+                font-size: $font-size-md;
+                font-weight: $font-weight-semibold;
+                color: $gray-800;
+            }
+            .widget-content {
+                font-size: $font-size-sm;
+                line-height: $line-height-relaxed;
+                color: $gray-600;
+                ul {
+                    margin: 0;
+                    padding-left: $spacing-md;
+                    li {
+                        margin-bottom: spacing(0.5);
+                        &:last-child {
+                            margin-bottom: 0;
+                        }
+                        a {
+                            color: $wp-admin-blue;
+                            text-decoration: none;
+                            &:hover {
+                                text-decoration: underline;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    // ==========================================================================
+    // SETTINGS ACTIONS
+    // ==========================================================================
+    .settings-actions {
+        position: sticky;
+        bottom: 0;
+        background-color: $white;
+        border-top: 1px solid $gray-200;
+        padding: $spacing-lg;
+        margin: $spacing-xl (-$spacing-lg) (-$spacing-lg);
+        border-radius: 0 0 $border-radius-lg $border-radius-lg;
+        .actions-content {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: $spacing-md;
+            max-width: 1200px;
+            margin: 0 auto;
+            @include mobile-up {
+                justify-content: flex-end;
+            }
+        }
+        .actions-primary {
+            display: flex;
+            gap: $spacing-sm;
+            .btn {
+                @include mobile-up {
+                    min-width: 120px;
+                }
+            }
+        }
+        .actions-secondary {
+            display: flex;
+            gap: spacing(0.5);
+            @include mobile-up {
+                order: -1;
+            }
+        }
+    }
+}

--- a/assets/src/scss_OLD/utilities/_helpers.scss
+++ b/assets/src/scss_OLD/utilities/_helpers.scss
@@ -1,0 +1,496 @@
+/**
+ * Helper Utilities
+ * 
+ * General utility classes for display, alignment, and common patterns.
+ */
+
+// ==========================================================================
+// DISPLAY UTILITIES
+// ==========================================================================
+.ecowitt-admin {
+    .d-none {
+        display: none !important;
+    }
+    .d-inline {
+        display: inline !important;
+    }
+    .d-inline-block {
+        display: inline-block !important;
+    }
+    .d-block {
+        display: block !important;
+    }
+    .d-flex {
+        display: flex !important;
+    }
+    .d-inline-flex {
+        display: inline-flex !important;
+    }
+    .d-grid {
+        display: grid !important;
+    }
+    .d-table {
+        display: table !important;
+    }
+    .d-table-cell {
+        display: table-cell !important;
+    }
+    // ==========================================================================
+    // FLEX UTILITIES
+    // ==========================================================================
+    // Flex direction
+    .flex-row {
+        flex-direction: row !important;
+    }
+    .flex-row-reverse {
+        flex-direction: row-reverse !important;
+    }
+    .flex-col {
+        flex-direction: column !important;
+    }
+    .flex-col-reverse {
+        flex-direction: column-reverse !important;
+    }
+    // Flex wrap
+    .flex-wrap {
+        flex-wrap: wrap !important;
+    }
+    .flex-nowrap {
+        flex-wrap: nowrap !important;
+    }
+    .flex-wrap-reverse {
+        flex-wrap: wrap-reverse !important;
+    }
+    // Justify content
+    .justify-start {
+        justify-content: flex-start !important;
+    }
+    .justify-end {
+        justify-content: flex-end !important;
+    }
+    .justify-center {
+        justify-content: center !important;
+    }
+    .justify-between {
+        justify-content: space-between !important;
+    }
+    .justify-around {
+        justify-content: space-around !important;
+    }
+    .justify-evenly {
+        justify-content: space-evenly !important;
+    }
+    // Align items
+    .items-start {
+        align-items: flex-start !important;
+    }
+    .items-end {
+        align-items: flex-end !important;
+    }
+    .items-center {
+        align-items: center !important;
+    }
+    .items-baseline {
+        align-items: baseline !important;
+    }
+    .items-stretch {
+        align-items: stretch !important;
+    }
+    // Align self
+    .self-auto {
+        align-self: auto !important;
+    }
+    .self-start {
+        align-self: flex-start !important;
+    }
+    .self-end {
+        align-self: flex-end !important;
+    }
+    .self-center {
+        align-self: center !important;
+    }
+    .self-stretch {
+        align-self: stretch !important;
+    }
+    // Flex grow/shrink
+    .flex-1 {
+        flex: 1 1 0% !important;
+    }
+    .flex-auto {
+        flex: 1 1 auto !important;
+    }
+    .flex-initial {
+        flex: 0 1 auto !important;
+    }
+    .flex-none {
+        flex: none !important;
+    }
+    .flex-grow {
+        flex-grow: 1 !important;
+    }
+    .flex-shrink {
+        flex-shrink: 1 !important;
+    }
+    .flex-shrink-0 {
+        flex-shrink: 0 !important;
+    }
+    // ==========================================================================
+    // GRID UTILITIES
+    // ==========================================================================
+    .grid-cols-1 {
+        grid-template-columns: repeat(1, minmax(0, 1fr)) !important;
+    }
+    .grid-cols-2 {
+        grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+    }
+    .grid-cols-3 {
+        grid-template-columns: repeat(3, minmax(0, 1fr)) !important;
+    }
+    .grid-cols-4 {
+        grid-template-columns: repeat(4, minmax(0, 1fr)) !important;
+    }
+    .grid-cols-6 {
+        grid-template-columns: repeat(6, minmax(0, 1fr)) !important;
+    }
+    .grid-cols-12 {
+        grid-template-columns: repeat(12, minmax(0, 1fr)) !important;
+    }
+    .col-span-1 {
+        grid-column: span 1 / span 1 !important;
+    }
+    .col-span-2 {
+        grid-column: span 2 / span 2 !important;
+    }
+    .col-span-3 {
+        grid-column: span 3 / span 3 !important;
+    }
+    .col-span-4 {
+        grid-column: span 4 / span 4 !important;
+    }
+    .col-span-6 {
+        grid-column: span 6 / span 6 !important;
+    }
+    .col-span-full {
+        grid-column: 1 / -1 !important;
+    }
+    // ==========================================================================
+    // POSITION UTILITIES
+    // ==========================================================================
+    .static {
+        position: static !important;
+    }
+    .fixed {
+        position: fixed !important;
+    }
+    .absolute {
+        position: absolute !important;
+    }
+    .relative {
+        position: relative !important;
+    }
+    .sticky {
+        position: sticky !important;
+    }
+    // ==========================================================================
+    // OVERFLOW UTILITIES
+    // ==========================================================================
+    .overflow-auto {
+        overflow: auto !important;
+    }
+    .overflow-hidden {
+        overflow: hidden !important;
+    }
+    .overflow-visible {
+        overflow: visible !important;
+    }
+    .overflow-scroll {
+        overflow: scroll !important;
+    }
+    .overflow-x-auto {
+        overflow-x: auto !important;
+    }
+    .overflow-x-hidden {
+        overflow-x: hidden !important;
+    }
+    .overflow-y-auto {
+        overflow-y: auto !important;
+    }
+    .overflow-y-hidden {
+        overflow-y: hidden !important;
+    }
+    // ==========================================================================
+    // WIDTH & HEIGHT UTILITIES
+    // ==========================================================================
+    .w-auto {
+        width: auto !important;
+    }
+    .w-full {
+        width: 100% !important;
+    }
+    .w-screen {
+        width: 100vw !important;
+    }
+    .w-min {
+        width: min-content !important;
+    }
+    .w-max {
+        width: max-content !important;
+    }
+    .h-auto {
+        height: auto !important;
+    }
+    .h-full {
+        height: 100% !important;
+    }
+    .h-screen {
+        height: 100vh !important;
+    }
+    .h-min {
+        height: min-content !important;
+    }
+    .h-max {
+        height: max-content !important;
+    }
+    // Min/max width
+    .min-w-0 {
+        min-width: 0px !important;
+    }
+    .min-w-full {
+        min-width: 100% !important;
+    }
+    .max-w-none {
+        max-width: none !important;
+    }
+    .max-w-full {
+        max-width: 100% !important;
+    }
+    .max-w-xs {
+        max-width: 320px !important;
+    }
+    .max-w-sm {
+        max-width: 384px !important;
+    }
+    .max-w-md {
+        max-width: 448px !important;
+    }
+    .max-w-lg {
+        max-width: 512px !important;
+    }
+    .max-w-xl {
+        max-width: 576px !important;
+    }
+    .max-w-2xl {
+        max-width: 672px !important;
+    }
+    .max-w-3xl {
+        max-width: 768px !important;
+    }
+    .max-w-4xl {
+        max-width: 896px !important;
+    }
+    // Min/max height
+    .min-h-0 {
+        min-height: 0px !important;
+    }
+    .min-h-full {
+        min-height: 100% !important;
+    }
+    .max-h-full {
+        max-height: 100% !important;
+    }
+    .max-h-screen {
+        max-height: 100vh !important;
+    }
+    // ==========================================================================
+    // VISIBILITY UTILITIES
+    // ==========================================================================
+    .visible {
+        visibility: visible !important;
+    }
+    .invisible {
+        visibility: hidden !important;
+    }
+    .opacity-0 {
+        opacity: 0 !important;
+    }
+    .opacity-25 {
+        opacity: 0.25 !important;
+    }
+    .opacity-50 {
+        opacity: 0.5 !important;
+    }
+    .opacity-75 {
+        opacity: 0.75 !important;
+    }
+    .opacity-100 {
+        opacity: 1 !important;
+    }
+    // ==========================================================================
+    // CURSOR UTILITIES
+    // ==========================================================================
+    .cursor-auto {
+        cursor: auto !important;
+    }
+    .cursor-default {
+        cursor: default !important;
+    }
+    .cursor-pointer {
+        cursor: pointer !important;
+    }
+    .cursor-wait {
+        cursor: wait !important;
+    }
+    .cursor-text {
+        cursor: text !important;
+    }
+    .cursor-move {
+        cursor: move !important;
+    }
+    .cursor-help {
+        cursor: help !important;
+    }
+    .cursor-not-allowed {
+        cursor: not-allowed !important;
+    }
+    // ==========================================================================
+    // BORDER UTILITIES
+    // ==========================================================================
+    .border {
+        border: $border-width solid $gray-200 !important;
+    }
+    .border-0 {
+        border: 0 !important;
+    }
+    .border-t {
+        border-top: $border-width solid $gray-200 !important;
+    }
+    .border-r {
+        border-right: $border-width solid $gray-200 !important;
+    }
+    .border-b {
+        border-bottom: $border-width solid $gray-200 !important;
+    }
+    .border-l {
+        border-left: $border-width solid $gray-200 !important;
+    }
+    // Border colors
+    .border-gray-100 {
+        border-color: $gray-100 !important;
+    }
+    .border-gray-200 {
+        border-color: $gray-200 !important;
+    }
+    .border-gray-300 {
+        border-color: $gray-300 !important;
+    }
+    .border-primary {
+        border-color: $wp-admin-blue !important;
+    }
+    .border-success {
+        border-color: $wp-success !important;
+    }
+    .border-warning {
+        border-color: $wp-warning !important;
+    }
+    .border-danger {
+        border-color: $wp-error !important;
+    }
+    // Border radius
+    .rounded-none {
+        border-radius: 0 !important;
+    }
+    .rounded-sm {
+        border-radius: $border-radius-sm !important;
+    }
+    .rounded {
+        border-radius: $border-radius-md !important;
+    }
+    .rounded-lg {
+        border-radius: $border-radius-lg !important;
+    }
+    .rounded-full {
+        border-radius: 9999px !important;
+    }
+    // ==========================================================================
+    // BACKGROUND UTILITIES
+    // ==========================================================================
+    .bg-transparent {
+        background-color: transparent !important;
+    }
+    .bg-white {
+        background-color: $white !important;
+    }
+    .bg-gray-50 {
+        background-color: $gray-50 !important;
+    }
+    .bg-gray-100 {
+        background-color: $gray-100 !important;
+    }
+    .bg-gray-200 {
+        background-color: $gray-200 !important;
+    }
+    .bg-primary {
+        background-color: $wp-admin-blue !important;
+    }
+    .bg-success {
+        background-color: $wp-success !important;
+    }
+    .bg-warning {
+        background-color: $wp-warning !important;
+    }
+    .bg-danger {
+        background-color: $wp-error !important;
+    }
+    // ==========================================================================
+    // SHADOW UTILITIES
+    // ==========================================================================
+    .shadow-none {
+        box-shadow: none !important;
+    }
+    .shadow-sm {
+        box-shadow: $shadow-sm !important;
+    }
+    .shadow {
+        box-shadow: $shadow-md !important;
+    }
+    .shadow-lg {
+        box-shadow: $shadow-lg !important;
+    }
+    // ==========================================================================
+    // INTERACTION UTILITIES
+    // ==========================================================================
+    .pointer-events-none {
+        pointer-events: none !important;
+    }
+    .pointer-events-auto {
+        pointer-events: auto !important;
+    }
+    .select-none {
+        user-select: none !important;
+    }
+    .select-text {
+        user-select: text !important;
+    }
+    .select-all {
+        user-select: all !important;
+    }
+    .select-auto {
+        user-select: auto !important;
+    }
+    // ==========================================================================
+    // ACCESSIBILITY UTILITIES
+    // ==========================================================================
+    .sr-only {
+        @include sr-only;
+    }
+    .not-sr-only {
+        position: static !important;
+        width: auto !important;
+        height: auto !important;
+        padding: 0 !important;
+        margin: 0 !important;
+        overflow: visible !important;
+        clip: auto !important;
+        white-space: normal !important;
+    }
+}

--- a/assets/src/scss_OLD/utilities/_spacing.scss
+++ b/assets/src/scss_OLD/utilities/_spacing.scss
@@ -1,0 +1,485 @@
+/**
+ * Spacing Utilities
+ * 
+ * Utility classes for consistent spacing throughout the admin interface.
+ * Based on the 8px spacing scale.
+ */
+
+// ==========================================================================
+// MARGIN UTILITIES
+// ==========================================================================
+.ecowitt-admin {
+    // All sides
+    .m-0 {
+        margin: 0 !important;
+    }
+    .m-xs {
+        margin: $spacing-xs !important;
+    }
+    .m-sm {
+        margin: $spacing-sm !important;
+    }
+    .m-md {
+        margin: $spacing-md !important;
+    }
+    .m-lg {
+        margin: $spacing-lg !important;
+    }
+    .m-xl {
+        margin: $spacing-xl !important;
+    }
+    .m-xxl {
+        margin: $spacing-xxl !important;
+    }
+    .m-xxxl {
+        margin: $spacing-xxxl !important;
+    }
+    // Top
+    .mt-0 {
+        margin-top: 0 !important;
+    }
+    .mt-xs {
+        margin-top: $spacing-xs !important;
+    }
+    .mt-sm {
+        margin-top: $spacing-sm !important;
+    }
+    .mt-md {
+        margin-top: $spacing-md !important;
+    }
+    .mt-lg {
+        margin-top: $spacing-lg !important;
+    }
+    .mt-xl {
+        margin-top: $spacing-xl !important;
+    }
+    .mt-xxl {
+        margin-top: $spacing-xxl !important;
+    }
+    .mt-xxxl {
+        margin-top: $spacing-xxxl !important;
+    }
+    // Right
+    .mr-0 {
+        margin-right: 0 !important;
+    }
+    .mr-xs {
+        margin-right: $spacing-xs !important;
+    }
+    .mr-sm {
+        margin-right: $spacing-sm !important;
+    }
+    .mr-md {
+        margin-right: $spacing-md !important;
+    }
+    .mr-lg {
+        margin-right: $spacing-lg !important;
+    }
+    .mr-xl {
+        margin-right: $spacing-xl !important;
+    }
+    .mr-xxl {
+        margin-right: $spacing-xxl !important;
+    }
+    .mr-xxxl {
+        margin-right: $spacing-xxxl !important;
+    }
+    // Bottom
+    .mb-0 {
+        margin-bottom: 0 !important;
+    }
+    .mb-xs {
+        margin-bottom: $spacing-xs !important;
+    }
+    .mb-sm {
+        margin-bottom: $spacing-sm !important;
+    }
+    .mb-md {
+        margin-bottom: $spacing-md !important;
+    }
+    .mb-lg {
+        margin-bottom: $spacing-lg !important;
+    }
+    .mb-xl {
+        margin-bottom: $spacing-xl !important;
+    }
+    .mb-xxl {
+        margin-bottom: $spacing-xxl !important;
+    }
+    .mb-xxxl {
+        margin-bottom: $spacing-xxxl !important;
+    }
+    // Left
+    .ml-0 {
+        margin-left: 0 !important;
+    }
+    .ml-xs {
+        margin-left: $spacing-xs !important;
+    }
+    .ml-sm {
+        margin-left: $spacing-sm !important;
+    }
+    .ml-md {
+        margin-left: $spacing-md !important;
+    }
+    .ml-lg {
+        margin-left: $spacing-lg !important;
+    }
+    .ml-xl {
+        margin-left: $spacing-xl !important;
+    }
+    .ml-xxl {
+        margin-left: $spacing-xxl !important;
+    }
+    .ml-xxxl {
+        margin-left: $spacing-xxxl !important;
+    }
+    // Horizontal (left and right)
+    .mx-0 {
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+    }
+    .mx-xs {
+        margin-left: $spacing-xs !important;
+        margin-right: $spacing-xs !important;
+    }
+    .mx-sm {
+        margin-left: $spacing-sm !important;
+        margin-right: $spacing-sm !important;
+    }
+    .mx-md {
+        margin-left: $spacing-md !important;
+        margin-right: $spacing-md !important;
+    }
+    .mx-lg {
+        margin-left: $spacing-lg !important;
+        margin-right: $spacing-lg !important;
+    }
+    .mx-xl {
+        margin-left: $spacing-xl !important;
+        margin-right: $spacing-xl !important;
+    }
+    .mx-xxl {
+        margin-left: $spacing-xxl !important;
+        margin-right: $spacing-xxl !important;
+    }
+    .mx-xxxl {
+        margin-left: $spacing-xxxl !important;
+        margin-right: $spacing-xxxl !important;
+    }
+    // Vertical (top and bottom)
+    .my-0 {
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+    }
+    .my-xs {
+        margin-top: $spacing-xs !important;
+        margin-bottom: $spacing-xs !important;
+    }
+    .my-sm {
+        margin-top: $spacing-sm !important;
+        margin-bottom: $spacing-sm !important;
+    }
+    .my-md {
+        margin-top: $spacing-md !important;
+        margin-bottom: $spacing-md !important;
+    }
+    .my-lg {
+        margin-top: $spacing-lg !important;
+        margin-bottom: $spacing-lg !important;
+    }
+    .my-xl {
+        margin-top: $spacing-xl !important;
+        margin-bottom: $spacing-xl !important;
+    }
+    .my-xxl {
+        margin-top: $spacing-xxl !important;
+        margin-bottom: $spacing-xxl !important;
+    }
+    .my-xxxl {
+        margin-top: $spacing-xxxl !important;
+        margin-bottom: $spacing-xxxl !important;
+    }
+    // Auto margins
+    .mx-auto {
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
+    .ml-auto {
+        margin-left: auto !important;
+    }
+    .mr-auto {
+        margin-right: auto !important;
+    }
+    // ==========================================================================
+    // PADDING UTILITIES
+    // ==========================================================================
+    // All sides
+    .p-0 {
+        padding: 0 !important;
+    }
+    .p-xs {
+        padding: $spacing-xs !important;
+    }
+    .p-sm {
+        padding: $spacing-sm !important;
+    }
+    .p-md {
+        padding: $spacing-md !important;
+    }
+    .p-lg {
+        padding: $spacing-lg !important;
+    }
+    .p-xl {
+        padding: $spacing-xl !important;
+    }
+    .p-xxl {
+        padding: $spacing-xxl !important;
+    }
+    .p-xxxl {
+        padding: $spacing-xxxl !important;
+    }
+    // Top
+    .pt-0 {
+        padding-top: 0 !important;
+    }
+    .pt-xs {
+        padding-top: $spacing-xs !important;
+    }
+    .pt-sm {
+        padding-top: $spacing-sm !important;
+    }
+    .pt-md {
+        padding-top: $spacing-md !important;
+    }
+    .pt-lg {
+        padding-top: $spacing-lg !important;
+    }
+    .pt-xl {
+        padding-top: $spacing-xl !important;
+    }
+    .pt-xxl {
+        padding-top: $spacing-xxl !important;
+    }
+    .pt-xxxl {
+        padding-top: $spacing-xxxl !important;
+    }
+    // Right
+    .pr-0 {
+        padding-right: 0 !important;
+    }
+    .pr-xs {
+        padding-right: $spacing-xs !important;
+    }
+    .pr-sm {
+        padding-right: $spacing-sm !important;
+    }
+    .pr-md {
+        padding-right: $spacing-md !important;
+    }
+    .pr-lg {
+        padding-right: $spacing-lg !important;
+    }
+    .pr-xl {
+        padding-right: $spacing-xl !important;
+    }
+    .pr-xxl {
+        padding-right: $spacing-xxl !important;
+    }
+    .pr-xxxl {
+        padding-right: $spacing-xxxl !important;
+    }
+    // Bottom
+    .pb-0 {
+        padding-bottom: 0 !important;
+    }
+    .pb-xs {
+        padding-bottom: $spacing-xs !important;
+    }
+    .pb-sm {
+        padding-bottom: $spacing-sm !important;
+    }
+    .pb-md {
+        padding-bottom: $spacing-md !important;
+    }
+    .pb-lg {
+        padding-bottom: $spacing-lg !important;
+    }
+    .pb-xl {
+        padding-bottom: $spacing-xl !important;
+    }
+    .pb-xxl {
+        padding-bottom: $spacing-xxl !important;
+    }
+    .pb-xxxl {
+        padding-bottom: $spacing-xxxl !important;
+    }
+    // Left
+    .pl-0 {
+        padding-left: 0 !important;
+    }
+    .pl-xs {
+        padding-left: $spacing-xs !important;
+    }
+    .pl-sm {
+        padding-left: $spacing-sm !important;
+    }
+    .pl-md {
+        padding-left: $spacing-md !important;
+    }
+    .pl-lg {
+        padding-left: $spacing-lg !important;
+    }
+    .pl-xl {
+        padding-left: $spacing-xl !important;
+    }
+    .pl-xxl {
+        padding-left: $spacing-xxl !important;
+    }
+    .pl-xxxl {
+        padding-left: $spacing-xxxl !important;
+    }
+    // Horizontal (left and right)
+    .px-0 {
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+    }
+    .px-xs {
+        padding-left: $spacing-xs !important;
+        padding-right: $spacing-xs !important;
+    }
+    .px-sm {
+        padding-left: $spacing-sm !important;
+        padding-right: $spacing-sm !important;
+    }
+    .px-md {
+        padding-left: $spacing-md !important;
+        padding-right: $spacing-md !important;
+    }
+    .px-lg {
+        padding-left: $spacing-lg !important;
+        padding-right: $spacing-lg !important;
+    }
+    .px-xl {
+        padding-left: $spacing-xl !important;
+        padding-right: $spacing-xl !important;
+    }
+    .px-xxl {
+        padding-left: $spacing-xxl !important;
+        padding-right: $spacing-xxl !important;
+    }
+    .px-xxxl {
+        padding-left: $spacing-xxxl !important;
+        padding-right: $spacing-xxxl !important;
+    }
+    // Vertical (top and bottom)
+    .py-0 {
+        padding-top: 0 !important;
+        padding-bottom: 0 !important;
+    }
+    .py-xs {
+        padding-top: $spacing-xs !important;
+        padding-bottom: $spacing-xs !important;
+    }
+    .py-sm {
+        padding-top: $spacing-sm !important;
+        padding-bottom: $spacing-sm !important;
+    }
+    .py-md {
+        padding-top: $spacing-md !important;
+        padding-bottom: $spacing-md !important;
+    }
+    .py-lg {
+        padding-top: $spacing-lg !important;
+        padding-bottom: $spacing-lg !important;
+    }
+    .py-xl {
+        padding-top: $spacing-xl !important;
+        padding-bottom: $spacing-xl !important;
+    }
+    .py-xxl {
+        padding-top: $spacing-xxl !important;
+        padding-bottom: $spacing-xxl !important;
+    }
+    .py-xxxl {
+        padding-top: $spacing-xxxl !important;
+        padding-bottom: $spacing-xxxl !important;
+    }
+    // ==========================================================================
+    // GAP UTILITIES (for flexbox and grid)
+    // ==========================================================================
+    .gap-0 {
+        gap: 0 !important;
+    }
+    .gap-xs {
+        gap: $spacing-xs !important;
+    }
+    .gap-sm {
+        gap: $spacing-sm !important;
+    }
+    .gap-md {
+        gap: $spacing-md !important;
+    }
+    .gap-lg {
+        gap: $spacing-lg !important;
+    }
+    .gap-xl {
+        gap: $spacing-xl !important;
+    }
+    .gap-xxl {
+        gap: $spacing-xxl !important;
+    }
+    .gap-xxxl {
+        gap: $spacing-xxxl !important;
+    }
+    // Row gap
+    .row-gap-0 {
+        row-gap: 0 !important;
+    }
+    .row-gap-xs {
+        row-gap: $spacing-xs !important;
+    }
+    .row-gap-sm {
+        row-gap: $spacing-sm !important;
+    }
+    .row-gap-md {
+        row-gap: $spacing-md !important;
+    }
+    .row-gap-lg {
+        row-gap: $spacing-lg !important;
+    }
+    .row-gap-xl {
+        row-gap: $spacing-xl !important;
+    }
+    .row-gap-xxl {
+        row-gap: $spacing-xxl !important;
+    }
+    .row-gap-xxxl {
+        row-gap: $spacing-xxxl !important;
+    }
+    // Column gap
+    .col-gap-0 {
+        column-gap: 0 !important;
+    }
+    .col-gap-xs {
+        column-gap: $spacing-xs !important;
+    }
+    .col-gap-sm {
+        column-gap: $spacing-sm !important;
+    }
+    .col-gap-md {
+        column-gap: $spacing-md !important;
+    }
+    .col-gap-lg {
+        column-gap: $spacing-lg !important;
+    }
+    .col-gap-xl {
+        column-gap: $spacing-xl !important;
+    }
+    .col-gap-xxl {
+        column-gap: $spacing-xxl !important;
+    }
+    .col-gap-xxxl {
+        column-gap: $spacing-xxxl !important;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "pinkcrab/ecowitt-weather-block",
     "type": "wordpress-plugin",
+
     "description": "A block to display weather data from an Ecowitt weather station.",
     "homepage": "https://github.com/gin0115/ecowitt-weather-block",
     "license": "GPL-3.0-or-later",
@@ -8,6 +9,7 @@
         "name": "Contributors",
         "homepage": "https://github.com/gin0115/ecowitt-weather-block/graphs/contributors"
     }],
+
     "repositories": [{
         "type": "vcs",
         "url": "https://github.com/Pink-Crab/codingstandards"
@@ -50,6 +52,7 @@
             "PinkCrab\\Ecowitt_Weather_Block\\Tests\\": "tests/"
         }
     },
+
     "scripts": {
         "test:php": "./vendor/bin/phpunit --coverage-html coverage-report --testdox --colors=always",
         "analyse:php": "./vendor/bin/phpstan analyse src -l9",
@@ -81,15 +84,18 @@
         "pipeline": [
             "@packages-install",
             "@test:php",
-            "@analyse:php"
-        ],
-        "config": {
-            "allow-plugins": {
-                "composer/*": true,
-                "dealerdirect/phpcodesniffer-composer-installer": true,
-                "phpstan/extension-installer": true,
-                "roots/wordpress-core-installer": true
-            }
-        },
-        "extra": {}
-    }
+            "@analyse:php",
+            "@lint:php"
+        ]
+    },
+    "config": {
+        "allow-plugins": {
+            "composer/*": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "phpstan/extension-installer": true,
+            "roots/wordpress-core-installer": true
+        }
+    },
+
+    "extra": {}
+}

--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,6 @@
             "@packages-install",
             "@test:php",
             "@analyse:php",
-            "@format:php",
             "@lint:php",
             "@internationalize"
         ]

--- a/composer.json
+++ b/composer.json
@@ -55,9 +55,9 @@
 
     "scripts": {
         "test:php": "./vendor/bin/phpunit --coverage-html coverage-report --testdox --colors=always",
-        "analyse:php": "./vendor/bin/phpstan analyse includes -l9",
-        "format:php": "./vendor/bin/phpcbf --standard=./.phpcs.xml --basepath=. -v",
-        "lint:php": "./vendor/bin/phpcs --standard=./.phpcs.xml --basepath=. -v",
+        "analyse:php": "./vendor/bin/phpstan analyse src -l9",
+        "format:php": "phpcbf src/ --basepath=. -v",
+        "lint:php": "phpcs src/ --basepath=. -v",
         "coverage": "./vendor/bin/phpunit --coverage-html coverage-report --testdox --colors=always",
         "internationalize": [
             "@makepot",

--- a/composer.json
+++ b/composer.json
@@ -77,8 +77,7 @@
             "@packages-install",
             "@test:php",
             "@analyse:php",
-            "@lint:php",
-            "@internationalize"
+            "@lint:php"
         ]
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,15 @@
 
     "repositories": [{
         "type": "vcs",
-        "url": "https://github.com/a8cteam51/team51-configs"
+        "url": "https://github.com/Pink-Crab/codingstandards"
     }],
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "pinkcrab/perique-framework-core": "^2.1"
+        "pinkcrab/perique-framework-core": "^2.1",
+        "pinkcrab/perique-admin-menu": "^2.1",
+        "pinkcrab/enqueue": "^1.4",
+        "pinkcrab/http": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5 || ^9.0",
@@ -36,24 +39,26 @@
         "gin0115/wpunit-helpers": "1.1.*",
         "vlucas/phpdotenv": "<=5.5.0",
         "doctrine/instantiator": "^1.5",
-        "phpcompatibility/php-compatibility": "*"
+        "phpcompatibility/php-compatibility": "*",
+        "pinkcrab/coding-standards": "dev-master"
     },
     "autoload": {
         "psr-4": {
-            "PinkCrab\\Eccowit_Weather_Block\\": "src"
+            "PinkCrab\\Ecowitt_Weather_Block\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "PinkCrab\\Eccowit_Weather_Block\\Tests\\": "tests/"
+            "PinkCrab\\Ecowitt_Weather_Block\\Tests\\": "tests/"
         }
     },
 
     "scripts": {
         "test:php": "./vendor/bin/phpunit --coverage-html coverage-report --testdox --colors=always",
         "analyse:php": "./vendor/bin/phpstan analyse includes -l9",
-        "format:php": "phpcbf --standard=./.phpcs.xml --basepath=. -v",
-        "lint:php": "phpcs --standard=./.phpcs.xml --basepath=. -v",
+        "format:php": "./vendor/bin/phpcbf --standard=./.phpcs.xml --basepath=. -v",
+        "lint:php": "./vendor/bin/phpcs --standard=./.phpcs.xml --basepath=. -v",
+        "coverage": "./vendor/bin/phpunit --coverage-html coverage-report --testdox --colors=always",
         "internationalize": [
             "@makepot",
             "@updatepo",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
     "name": "pinkcrab/ecowitt-weather-block",
     "type": "wordpress-plugin",
-
     "description": "A block to display weather data from an Ecowitt weather station.",
     "homepage": "https://github.com/gin0115/ecowitt-weather-block",
     "license": "GPL-3.0-or-later",
@@ -9,7 +8,6 @@
         "name": "Contributors",
         "homepage": "https://github.com/gin0115/ecowitt-weather-block/graphs/contributors"
     }],
-
     "repositories": [{
         "type": "vcs",
         "url": "https://github.com/Pink-Crab/codingstandards"
@@ -52,7 +50,6 @@
             "PinkCrab\\Ecowitt_Weather_Block\\Tests\\": "tests/"
         }
     },
-
     "scripts": {
         "test:php": "./vendor/bin/phpunit --coverage-html coverage-report --testdox --colors=always",
         "analyse:php": "./vendor/bin/phpstan analyse src -l9",
@@ -77,17 +74,22 @@
             "@packages-install",
             "@test:php",
             "@analyse:php",
-            "@lint:php"
-        ]
-    },
-    "config": {
-        "allow-plugins": {
-            "composer/*": true,
-            "dealerdirect/phpcodesniffer-composer-installer": true,
-            "phpstan/extension-installer": true,
-            "roots/wordpress-core-installer": true
-        }
-    },
-
-    "extra": {}
-}
+            "@format:php",
+            "@lint:php",
+            "@internationalize"
+        ],
+        "pipeline": [
+            "@packages-install",
+            "@test:php",
+            "@analyse:php"
+        ],
+        "config": {
+            "allow-plugins": {
+                "composer/*": true,
+                "dealerdirect/phpcodesniffer-composer-installer": true,
+                "phpstan/extension-installer": true,
+                "roots/wordpress-core-installer": true
+            }
+        },
+        "extra": {}
+    }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "171af9e2a6c0406326fc39e8a591e544",
+    "content-hash": "5e7dac4ca34763f4a92fdb156fadd2e7",
     "packages": [
         {
             "name": "gin0115/dice",
@@ -54,6 +54,211 @@
                 "source": "https://github.com/gin0115/Dice/tree/4.1.0"
             },
             "time": "2023-03-22T16:03:18+00:00"
+        },
+        {
+            "name": "nyholm/psr7",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nyholm/psr7.git",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nyholm/psr7/zipball/a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "reference": "a71f2b11690f4b24d099d6b16690a90ae14fc6f3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0"
+            },
+            "provide": {
+                "php-http/message-factory-implementation": "1.0",
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "http-interop/http-factory-tests": "^0.9",
+                "php-http/message-factory": "^1.0",
+                "php-http/psr7-integration-tests": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.4",
+                "symfony/error-handler": "^4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "A fast PHP7 implementation of PSR-7",
+            "homepage": "https://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7/issues",
+                "source": "https://github.com/Nyholm/psr7/tree/1.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-09-09T07:06:30+00:00"
+        },
+        {
+            "name": "nyholm/psr7-server",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Nyholm/psr7-server.git",
+                "reference": "4335801d851f554ca43fa6e7d2602141538854dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Nyholm/psr7-server/zipball/4335801d851f554ca43fa6e7d2602141538854dc",
+                "reference": "4335801d851f554ca43fa6e7d2602141538854dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "nyholm/nsa": "^1.1",
+                "nyholm/psr7": "^1.3",
+                "phpunit/phpunit": "^7.0 || ^8.5 || ^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Nyholm\\Psr7Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tobias Nyholm",
+                    "email": "tobias.nyholm@gmail.com"
+                },
+                {
+                    "name": "Martijn van der Ven",
+                    "email": "martijn@vanderven.se"
+                }
+            ],
+            "description": "Helper classes to handle PSR-7 server requests",
+            "homepage": "http://tnyholm.se",
+            "keywords": [
+                "psr-17",
+                "psr-7"
+            ],
+            "support": {
+                "issues": "https://github.com/Nyholm/psr7-server/issues",
+                "source": "https://github.com/Nyholm/psr7-server/tree/1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Zegnat",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nyholm",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-11-08T09:30:43+00:00"
+        },
+        {
+            "name": "pinkcrab/enqueue",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Pink-Crab/Enqueue.git",
+                "reference": "640af405296d8e26ed0b2ab8e366851a21b8311c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Pink-Crab/Enqueue/zipball/640af405296d8e26ed0b2ab8e366851a21b8311c",
+                "reference": "640af405296d8e26ed0b2ab8e366851a21b8311c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "<=1.0.0",
+                "gin0115/wpunit-helpers": "1.1.*",
+                "php-stubs/wordpress-stubs": "6.* || 5.9.*",
+                "phpstan/phpstan": "1.*",
+                "phpunit/phpunit": "^7.0 || ^8.0",
+                "pinkcrab/function-constructors": "0.2.*",
+                "roots/wordpress": "6.1.*",
+                "symfony/css-selector": "<=6.2.7",
+                "symfony/dom-crawler": "<=6.2.7",
+                "symfony/var-dumper": "<=6.2.7",
+                "szepeviktor/phpstan-wordpress": "<=1.1.7",
+                "vlucas/phpdotenv": "<=5.5.0",
+                "wp-coding-standards/wpcs": "<=2.3.0",
+                "wp-phpunit/wp-phpunit": "6.1.*",
+                "yoast/phpunit-polyfills": "^0.2.0 || ^1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [],
+                "psr-4": {
+                    "PinkCrab\\Enqueue\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Glynn Quelch",
+                    "email": "glynn@pinkcrab.co.uk",
+                    "homepage": "http://clappo.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A fluent API for enqueuing WordPress Scripts and Styles.",
+            "homepage": "https://pinkcrab.co.uk",
+            "support": {
+                "issues": "https://github.com/Pink-Crab/Enqueue/issues",
+                "source": "https://github.com/Pink-Crab/Enqueue/tree/1.4.0"
+            },
+            "time": "2023-03-05T00:04:35+00:00"
         },
         {
             "name": "pinkcrab/function-constructors",
@@ -183,6 +388,131 @@
             "time": "2022-05-27T11:49:19+00:00"
         },
         {
+            "name": "pinkcrab/http",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Pink-Crab/HTTP.git",
+                "reference": "5fca8154b1db6c05a763867b2751295527803ae9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Pink-Crab/HTTP/zipball/5fca8154b1db6c05a763867b2751295527803ae9",
+                "reference": "5fca8154b1db6c05a763867b2751295527803ae9",
+                "shasum": ""
+            },
+            "require": {
+                "nyholm/psr7": "^1.3",
+                "nyholm/psr7-server": "^1.0",
+                "php": ">=7.4.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "*",
+                "gin0115/wpunit-helpers": "~1",
+                "php-stubs/wordpress-stubs": "6.7.*",
+                "phpcompatibility/php-compatibility": "*",
+                "phpstan/phpstan": "1.*",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "roave/security-advisories": "dev-latest",
+                "roots/wordpress": "6.7.*",
+                "squizlabs/php_codesniffer": "3.*",
+                "symfony/var-dumper": "*",
+                "szepeviktor/phpstan-wordpress": "<=1.3.2",
+                "vlucas/phpdotenv": "^5.4",
+                "wp-coding-standards/wpcs": "^3",
+                "wp-phpunit/wp-phpunit": "6.7.*",
+                "yoast/phpunit-polyfills": "^1.0.0 || ^2.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [],
+                "psr-4": {
+                    "PinkCrab\\HTTP\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Glynn Quelch",
+                    "email": "glynn.quelch@pinkcrab.co.uk",
+                    "homepage": "http://clappo.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Wrapper around Nyholm\\Psr7 library with a few helper methods and a basic emitter. For use in WordPress during ajax calls.",
+            "homepage": "https://pinkcrab.co.uk",
+            "support": {
+                "issues": "https://github.com/Pink-Crab/HTTP/issues",
+                "source": "https://github.com/Pink-Crab/HTTP/tree/1.1.0"
+            },
+            "time": "2025-01-30T23:10:17+00:00"
+        },
+        {
+            "name": "pinkcrab/perique-admin-menu",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Pink-Crab/Perique_Admin_Menu.git",
+                "reference": "2ca96e6c21b0cebc82bc331aa6f0cb5f028443cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Pink-Crab/Perique_Admin_Menu/zipball/2ca96e6c21b0cebc82bc331aa6f0cb5f028443cf",
+                "reference": "2ca96e6c21b0cebc82bc331aa6f0cb5f028443cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0",
+                "pinkcrab/perique-framework-core": "2.1.*"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "*",
+                "gin0115/wpunit-helpers": "1.1.*",
+                "php-stubs/wordpress-stubs": "6.6.*",
+                "phpstan/phpstan": "1.*",
+                "phpunit/phpunit": "^7.0 || ^8.0",
+                "roave/security-advisories": "dev-latest",
+                "roots/wordpress": "6.6.*",
+                "squizlabs/php_codesniffer": "3.*",
+                "symfony/var-dumper": "<=6.2.7",
+                "szepeviktor/phpstan-wordpress": "<=1.1.7",
+                "vlucas/phpdotenv": "<=5.5.0",
+                "wp-cli/i18n-command": "*",
+                "wp-coding-standards/wpcs": "^3",
+                "wp-phpunit/wp-phpunit": "6.6.*",
+                "yoast/phpunit-polyfills": "^0.2.0 || ^1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [],
+                "psr-4": {
+                    "PinkCrab\\Perique_Admin_Menu\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Glynn Quelch",
+                    "email": "glynn.quelch@pinkcrab.co.uk",
+                    "homepage": "http://clappo.co.uk",
+                    "role": "Developer"
+                }
+            ],
+            "description": "The PinkCrab framework package for creating admin pages/groups using inheritance very easyly from plugins and themes.",
+            "homepage": "https://pinkcrab.co.uk",
+            "support": {
+                "issues": "https://github.com/Pink-Crab/Perique_Admin_Menu/issues",
+                "source": "https://github.com/Pink-Crab/Perique_Admin_Menu/tree/2.1.0"
+            },
+            "time": "2025-01-28T09:45:32+00:00"
+        },
+        {
             "name": "pinkcrab/perique-framework-core",
             "version": "2.1.0",
             "source": {
@@ -295,31 +625,139 @@
                 "source": "https://github.com/php-fig/container/tree/1.1.2"
             },
             "time": "2021-11-05T16:50:12+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "automattic/jetpack-constants",
-            "version": "v3.0.5",
+            "version": "v3.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-constants.git",
-                "reference": "12446dd21985e3765d8b8b903091c273d22e4e9e"
+                "reference": "f9bf00ab48956b8326209e7c0baf247a0ed721c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/12446dd21985e3765d8b8b903091c273d22e4e9e",
-                "reference": "12446dd21985e3765d8b8b903091c273d22e4e9e",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/f9bf00ab48956b8326209e7c0baf247a0ed721c4",
+                "reference": "f9bf00ab48956b8326209e7c0baf247a0ed721c4",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/jetpack-changelogger": "^6.0.2",
-                "automattic/phpunit-select-config": "^1.0.1",
+                "automattic/jetpack-changelogger": "^6.0.5",
+                "automattic/phpunit-select-config": "^1.0.3",
                 "brain/monkey": "^2.6.2",
-                "yoast/phpunit-polyfills": "^3.0.0"
+                "yoast/phpunit-polyfills": "^4.0.0"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -346,34 +784,34 @@
             ],
             "description": "A wrapper for defining constants in a more testable way.",
             "support": {
-                "source": "https://github.com/Automattic/jetpack-constants/tree/v3.0.5"
+                "source": "https://github.com/Automattic/jetpack-constants/tree/v3.0.8"
             },
-            "time": "2025-03-21T09:05:24+00:00"
+            "time": "2025-04-28T15:12:45+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
+                "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
+                "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "yoast/phpunit-polyfills": "^1.0"
             },
@@ -393,9 +831,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
@@ -403,7 +841,6 @@
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -424,9 +861,28 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -835,16 +1291,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.17.0",
+            "version": "v1.17.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "3a752d39bd7d8dc1e19bcf424f3d5ac1a1ca6ad5"
+                "reference": "465810689c477fbba17f4f949b75e4d0bdab13ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/3a752d39bd7d8dc1e19bcf424f3d5ac1a1ca6ad5",
-                "reference": "3a752d39bd7d8dc1e19bcf424f3d5ac1a1ca6ad5",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/465810689c477fbba17f4f949b75e4d0bdab13ea",
+                "reference": "465810689c477fbba17f4f949b75e4d0bdab13ea",
                 "shasum": ""
             },
             "require": {
@@ -857,7 +1313,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17.0-dev"
+                    "dev-master": "1.17.2-dev"
                 }
             },
             "autoload": {
@@ -878,72 +1334,22 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.17.0"
+                "source": "https://github.com/mck89/peast/tree/v1.17.2"
             },
-            "time": "2025-03-07T19:44:14+00:00"
-        },
-        {
-            "name": "mustache/mustache",
-            "version": "v2.14.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bobthecow/mustache.php.git",
-                "reference": "e62b7c3849d22ec55f3ec425507bf7968193a6cb"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/mustache.php/zipball/e62b7c3849d22ec55f3ec425507bf7968193a6cb",
-                "reference": "e62b7c3849d22ec55f3ec425507bf7968193a6cb",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.4"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "~1.11",
-                "phpunit/phpunit": "~3.7|~4.0|~5.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Mustache": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Justin Hileman",
-                    "email": "justin@justinhileman.info",
-                    "homepage": "http://justinhileman.com"
-                }
-            ],
-            "description": "A Mustache implementation in PHP.",
-            "homepage": "https://github.com/bobthecow/mustache.php",
-            "keywords": [
-                "mustache",
-                "templating"
-            ],
-            "support": {
-                "issues": "https://github.com/bobthecow/mustache.php/issues",
-                "source": "https://github.com/bobthecow/mustache.php/tree/v2.14.2"
-            },
-            "time": "2022-08-23T13:07:01+00:00"
+            "time": "2025-07-01T09:30:45+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.0",
+            "version": "1.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
-                "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
                 "shasum": ""
             },
             "require": {
@@ -982,7 +1388,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
             },
             "funding": [
                 {
@@ -990,20 +1396,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-12T12:17:51+00:00"
+            "time": "2025-08-01T08:46:24+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
                 "shasum": ""
             },
             "require": {
@@ -1022,7 +1428,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -1046,9 +1452,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-08-13T20:13:15+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -1280,29 +1686,29 @@
         },
         {
             "name": "phpcsstandards/phpcsextra",
-            "version": "1.2.1",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+                "reference": "882b8c947ada27eb002870fe77fee9ce0a454cdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
-                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/882b8c947ada27eb002870fe77fee9ce0a454cdb",
+                "reference": "882b8c947ada27eb002870fe77fee9ce0a454cdb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.9",
-                "squizlabs/php_codesniffer": "^3.8.0"
+                "phpcsstandards/phpcsutils": "^1.1.2",
+                "squizlabs/php_codesniffer": "^3.13.4 || ^4.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
                 "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -1352,35 +1758,39 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2023-12-08T16:49:07+00:00"
+            "time": "2025-09-05T06:54:52+00:00"
         },
         {
             "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.12",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c"
+                "reference": "b22b59e3d9ec8fe4953e42c7d59117c6eae70eae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/87b233b00daf83fb70f40c9a28692be017ea7c6c",
-                "reference": "87b233b00daf83fb70f40c9a28692be017ea7c6c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/b22b59e3d9ec8fe4953e42c7d59117c6eae70eae",
+                "reference": "b22b59e3d9ec8fe4953e42c7d59117c6eae70eae",
                 "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.10.0 || 4.0.x-dev@dev"
+                "squizlabs/php_codesniffer": "^3.13.3 || ^4.0"
             },
             "require-dev": {
                 "ext-filter": "*",
                 "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -1417,6 +1827,7 @@
                 "phpcodesniffer-standard",
                 "phpcs",
                 "phpcs3",
+                "phpcs4",
                 "standards",
                 "static analysis",
                 "tokens",
@@ -1440,22 +1851,26 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-05-20T13:34:27+00:00"
+            "time": "2025-09-05T00:00:03+00:00"
         },
         {
             "name": "phpoption/phpoption",
-            "version": "1.9.3",
+            "version": "1.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/schmittjoh/php-option.git",
-                "reference": "e3fac8b24f56113f7cb96af14958c0dd16330f54"
+                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/e3fac8b24f56113f7cb96af14958c0dd16330f54",
-                "reference": "e3fac8b24f56113f7cb96af14958c0dd16330f54",
+                "url": "https://api.github.com/repos/schmittjoh/php-option/zipball/638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
+                "reference": "638a154f8d4ee6a5cfa96d6a34dfbe0cffa9566d",
                 "shasum": ""
             },
             "require": {
@@ -1463,7 +1878,7 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20 || ^10.5.28"
+                "phpunit/phpunit": "^8.5.44 || ^9.6.25 || ^10.5.53 || ^11.5.34"
             },
             "type": "library",
             "extra": {
@@ -1505,7 +1920,7 @@
             ],
             "support": {
                 "issues": "https://github.com/schmittjoh/php-option/issues",
-                "source": "https://github.com/schmittjoh/php-option/tree/1.9.3"
+                "source": "https://github.com/schmittjoh/php-option/tree/1.9.4"
             },
             "funding": [
                 {
@@ -1517,20 +1932,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-20T21:41:07+00:00"
+            "time": "2025-08-21T11:53:16+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.23",
+            "version": "1.12.28",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "29201e7a743a6ab36f91394eab51889a82631428"
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/29201e7a743a6ab36f91394eab51889a82631428",
-                "reference": "29201e7a743a6ab36f91394eab51889a82631428",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
                 "shasum": ""
             },
             "require": {
@@ -1575,7 +1990,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-23T14:57:32+00:00"
+            "time": "2025-07-17T17:15:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1898,16 +2313,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.22",
+            "version": "9.6.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
+                "reference": "049c011e01be805202d8eebedef49f769a8ec7b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
-                "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/049c011e01be805202d8eebedef49f769a8ec7b7",
+                "reference": "049c011e01be805202d8eebedef49f769a8ec7b7",
                 "shasum": ""
             },
             "require": {
@@ -1918,7 +2333,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.12.1",
+                "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=7.3",
@@ -1929,11 +2344,11 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.8",
+                "sebastian/comparator": "^4.0.9",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.6",
-                "sebastian/global-state": "^5.0.7",
+                "sebastian/global-state": "^5.0.8",
                 "sebastian/object-enumerator": "^4.0.4",
                 "sebastian/resource-operations": "^3.0.4",
                 "sebastian/type": "^3.2.1",
@@ -1981,7 +2396,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.25"
             },
             "funding": [
                 {
@@ -1993,11 +2408,83 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-05T13:48:26+00:00"
+            "time": "2025-08-20T14:38:31+00:00"
+        },
+        {
+            "name": "pinkcrab/coding-standards",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Pink-Crab/codingstandards.git",
+                "reference": "17640c5e6a3d8191c43501c659a79ba0f5b5ebd4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Pink-Crab/codingstandards/zipball/17640c5e6a3d8191c43501c659a79ba0f5b5ebd4",
+                "reference": "17640c5e6a3d8191c43501c659a79ba0f5b5ebd4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "default-branch": true,
+            "type": "phpcodesniffer-standard",
+            "scripts": {
+                "post-install-cmd": [
+                    "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
+                ],
+                "post-update-cmd": [
+                    "\"vendor/bin/phpcs\" --config-set installed_paths ../../.."
+                ]
+            },
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Glynn Quelch",
+                    "homepage": "https://github.com/gin0115"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Pink-Crab/codingstandards/graphs/contributors"
+                }
+            ],
+            "description": "Custom set of phpcs rules for PinkCrab",
+            "homepage": "https://github.com/Pink-Crab/codingstandards",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/Pink-Crab/codingstandards/issues",
+                "source": "https://github.com/Pink-Crab/codingstandards"
+            },
+            "time": "2023-10-20T22:24:40+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -2005,18 +2492,19 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "497afc97765c92fa7265e3d33bce240b33e4e6f2"
+                "reference": "dc5c4ede5c331ae21fb68947ff89672df9b7cc7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/497afc97765c92fa7265e3d33bce240b33e4e6f2",
-                "reference": "497afc97765c92fa7265e3d33bce240b33e4e6f2",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/dc5c4ede5c331ae21fb68947ff89672df9b7cc7d",
+                "reference": "dc5c4ede5c331ae21fb68947ff89672df9b7cc7d",
                 "shasum": ""
             },
             "conflict": {
                 "3f/pygmentize": "<1.2",
+                "adaptcms/adaptcms": "<=1.3",
                 "admidio/admidio": "<4.3.12",
-                "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
+                "adodb/adodb-php": "<=5.22.9",
                 "aheinze/cockpit": "<2.2",
                 "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.07.2",
                 "aimeos/ai-admin-jsonadm": "<2020.10.13|>=2021.04.1,<2021.10.6|>=2022.04.1,<2022.10.3|>=2023.04.1,<2023.10.4|==2024.04.1",
@@ -2027,7 +2515,7 @@
                 "airesvsg/acf-to-rest-api": "<=3.1",
                 "akaunting/akaunting": "<2.1.13",
                 "akeneo/pim-community-dev": "<5.0.119|>=6,<6.0.53",
-                "alextselegidis/easyappointments": "<=1.5",
+                "alextselegidis/easyappointments": "<1.5.2.0-beta1",
                 "alterphp/easyadmin-extension-bundle": ">=1.2,<1.2.11|>=1.3,<1.3.1",
                 "amazing/media2click": ">=1,<1.3.3",
                 "ameos/ameos_tarteaucitron": "<1.2.23",
@@ -2037,9 +2525,11 @@
                 "anchorcms/anchor-cms": "<=0.12.7",
                 "andreapollastri/cipi": "<=3.1.15",
                 "andrewhaine/silverstripe-form-capture": ">=0.2,<=0.2.3|>=1,<1.0.2|>=2,<2.2.5",
+                "aoe/restler": "<1.7.1",
                 "apache-solr-for-typo3/solr": "<2.8.3",
                 "apereo/phpcas": "<1.6",
-                "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6|>=2.6,<2.7.10|>=3,<3.0.12|>=3.1,<3.1.3|>=3.3.8,<3.3.15",
+                "api-platform/core": "<3.4.17|>=4,<4.0.22|>=4.1,<4.1.5",
+                "api-platform/graphql": "<3.4.17|>=4,<4.0.22|>=4.1,<4.1.5",
                 "appwrite/server-ce": "<=1.2.1",
                 "arc/web": "<3",
                 "area17/twill": "<1.2.5|>=2,<2.5.3",
@@ -2049,29 +2539,36 @@
                 "athlon1600/php-proxy-app": "<=3",
                 "athlon1600/youtube-downloader": "<=4",
                 "austintoddj/canvas": "<=3.4.2",
-                "auth0/wordpress": "<=4.6",
+                "auth0/auth0-php": ">=8.0.0.0-beta1,<8.14",
+                "auth0/login": "<7.17",
+                "auth0/symfony": "<5.4",
+                "auth0/wordpress": "<5.3",
                 "automad/automad": "<2.0.0.0-alpha5",
                 "automattic/jetpack": "<9.8",
                 "awesome-support/awesome-support": "<=6.0.7",
                 "aws/aws-sdk-php": "<3.288.1",
                 "azuracast/azuracast": "<0.18.3",
+                "b13/seo_basics": "<0.8.2",
                 "backdrop/backdrop": "<1.27.3|>=1.28,<1.28.2",
                 "backpack/crud": "<3.4.9",
                 "backpack/filemanager": "<2.0.2|>=3,<3.0.9",
-                "bacula-web/bacula-web": "<8.0.0.0-RC2-dev",
-                "badaso/core": "<2.7",
+                "bacula-web/bacula-web": "<9.7.1",
+                "badaso/core": "<=2.9.11",
                 "bagisto/bagisto": "<2.1",
                 "barrelstrength/sprout-base-email": "<1.2.7",
                 "barrelstrength/sprout-forms": "<3.9",
-                "barryvdh/laravel-translation-manager": "<0.6.2",
+                "barryvdh/laravel-translation-manager": "<0.6.8",
                 "barzahlen/barzahlen-php": "<2.0.1",
                 "baserproject/basercms": "<=5.1.1",
                 "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
                 "bbpress/bbpress": "<2.6.5",
+                "bcit-ci/codeigniter": "<3.1.3",
                 "bcosca/fatfree": "<3.7.2",
                 "bedita/bedita": "<4",
+                "bednee/cooluri": "<1.0.30",
                 "bigfork/silverstripe-form-capture": ">=3,<3.1.1",
-                "billz/raspap-webgui": "<=3.1.4",
+                "billz/raspap-webgui": "<3.3.6",
+                "binarytorch/larecipe": "<2.8.1",
                 "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
                 "blueimp/jquery-file-upload": "==6.4.4",
                 "bmarshall511/wordpress_zero_spam": "<5.2.13",
@@ -2086,6 +2583,7 @@
                 "brotkrueml/typo3-matomo-integration": "<1.3.2",
                 "buddypress/buddypress": "<7.2.1",
                 "bugsnag/bugsnag-laravel": ">=2,<2.0.2",
+                "bvbmedia/multishop": "<2.0.39",
                 "bytefury/crater": "<6.0.2",
                 "cachethq/cachet": "<2.5.1",
                 "cakephp/cakephp": "<3.10.3|>=4,<4.0.10|>=4.1,<4.1.4|>=4.2,<4.2.12|>=4.3,<4.3.11|>=4.4,<4.4.10",
@@ -2101,30 +2599,34 @@
                 "centreon/centreon": "<22.10.15",
                 "cesnet/simplesamlphp-module-proxystatistics": "<3.1",
                 "chriskacerguis/codeigniter-restserver": "<=2.7.1",
+                "chrome-php/chrome": "<1.14",
                 "civicrm/civicrm-core": ">=4.2,<4.2.9|>=4.3,<4.3.3",
                 "ckeditor/ckeditor": "<4.25",
-                "clickstorm/cs-seo": ">=6,<6.7|>=7,<7.4|>=8,<8.3|>=9,<9.2",
-                "cockpit-hq/cockpit": "<2.7|==2.7",
+                "clickstorm/cs-seo": ">=6,<6.8|>=7,<7.5|>=8,<8.4|>=9,<9.3",
+                "co-stack/fal_sftp": "<0.2.6",
+                "cockpit-hq/cockpit": "<2.11.4",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
-                "codeigniter/framework": "<3.1.9",
-                "codeigniter4/framework": "<4.5.8",
+                "codeigniter/framework": "<3.1.10",
+                "codeigniter4/framework": "<4.6.2",
                 "codeigniter4/shield": "<1.0.0.0-beta8",
                 "codiad/codiad": "<=2.8.4",
                 "codingms/additional-tca": ">=1.7,<1.15.17|>=1.16,<1.16.9",
+                "commerceteam/commerce": ">=0.9.6,<0.9.9",
                 "components/jquery": ">=1.0.3,<3.5",
                 "composer/composer": "<1.10.27|>=2,<2.2.24|>=2.3,<2.7.7",
-                "concrete5/concrete5": "<9.4.0.0-RC1-dev",
+                "concrete5/concrete5": "<9.4.3",
                 "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
                 "contao/comments-bundle": ">=2,<4.13.40|>=5.0.0.0-RC1-dev,<5.3.4",
-                "contao/contao": "<=5.4.1",
+                "contao/contao": ">=3,<3.5.37|>=4,<4.4.56|>=4.5,<4.13.56|>=5,<5.3.38|>=5.4.0.0-RC1-dev,<5.6.1",
                 "contao/core": "<3.5.39",
-                "contao/core-bundle": "<4.13.54|>=5,<5.3.30|>=5.4,<5.5.6",
+                "contao/core-bundle": "<4.13.56|>=5,<5.3.38|>=5.4,<5.6.1",
                 "contao/listing-bundle": ">=3,<=3.5.30|>=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
                 "corveda/phpsandbox": "<1.3.5",
                 "cosenary/instagram": "<=2.3",
-                "craftcms/cms": "<4.13.8|>=5,<5.5.5",
+                "couleurcitron/tarteaucitron-wp": "<0.3",
+                "craftcms/cms": "<=4.16.5|>=5,<=5.8.6",
                 "croogo/croogo": "<4",
                 "cuyz/valinor": "<0.12",
                 "czim/file-handling": "<1.5|>=2,<2.3",
@@ -2142,7 +2644,11 @@
                 "desperado/xml-bundle": "<=0.1.7",
                 "dev-lancer/minecraft-motd-parser": "<=1.0.5",
                 "devgroup/dotplant": "<2020.09.14-dev",
+                "digimix/wp-svg-upload": "<=1",
                 "directmailteam/direct-mail": "<6.0.3|>=7,<7.0.3|>=8,<9.5.2",
+                "dl/yag": "<3.0.1",
+                "dmk/webkitpdf": "<1.1.4",
+                "dnadesign/silverstripe-elemental": "<5.3.12",
                 "doctrine/annotations": "<1.2.7",
                 "doctrine/cache": ">=1,<1.3.2|>=1.4,<1.4.2",
                 "doctrine/common": "<2.4.3|>=2.5,<2.5.1",
@@ -2152,12 +2658,33 @@
                 "doctrine/mongodb-odm": "<1.0.2",
                 "doctrine/mongodb-odm-bundle": "<3.0.1",
                 "doctrine/orm": ">=1,<1.2.4|>=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
-                "dolibarr/dolibarr": "<19.0.2|==21.0.0.0-beta",
+                "dolibarr/dolibarr": "<=21.0.2",
                 "dompdf/dompdf": "<2.0.4",
                 "doublethreedigital/guest-entries": "<3.1.2",
-                "drupal/core": ">=6,<6.38|>=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
+                "drupal/admin_audit_trail": "<1.0.5",
+                "drupal/ai": "<1.0.5",
+                "drupal/alogin": "<2.0.6",
+                "drupal/cache_utility": "<1.2.1",
+                "drupal/commerce_alphabank_redirect": "<1.0.3",
+                "drupal/commerce_eurobank_redirect": "<2.1.1",
+                "drupal/config_split": "<1.10|>=2,<2.0.2",
+                "drupal/core": ">=6,<6.38|>=7,<7.102|>=8,<10.3.14|>=10.4,<10.4.5|>=11,<11.0.13|>=11.1,<11.1.5",
                 "drupal/core-recommended": ">=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
                 "drupal/drupal": ">=5,<5.11|>=6,<6.38|>=7,<7.102|>=8,<10.2.11|>=10.3,<10.3.9|>=11,<11.0.8",
+                "drupal/formatter_suite": "<2.1",
+                "drupal/gdpr": "<3.0.1|>=3.1,<3.1.2",
+                "drupal/google_tag": "<1.8|>=2,<2.0.8",
+                "drupal/ignition": "<1.0.4",
+                "drupal/lightgallery": "<1.6",
+                "drupal/link_field_display_mode_formatter": "<1.6",
+                "drupal/matomo": "<1.24",
+                "drupal/oauth2_client": "<4.1.3",
+                "drupal/oauth2_server": "<2.1",
+                "drupal/obfuscate": "<2.0.1",
+                "drupal/quick_node_block": "<2",
+                "drupal/rapidoc_elements_field_formatter": "<1.0.1",
+                "drupal/spamspan": "<3.2.1",
+                "drupal/tfa": "<1.10",
                 "duncanmcclean/guest-entries": "<3.1.2",
                 "dweeves/magmi": "<=0.7.24",
                 "ec-cube/ec-cube": "<2.4.4|>=2.11,<=2.17.1|>=3,<=3.0.18.0-patch4|>=4,<=4.1.2",
@@ -2167,10 +2694,11 @@
                 "elefant/cms": "<2.0.7",
                 "elgg/elgg": "<3.3.24|>=4,<4.0.5",
                 "elijaa/phpmemcacheadmin": "<=1.3",
+                "elmsln/haxcms": "<11.0.14",
                 "encore/laravel-admin": "<=1.8.19",
                 "endroid/qr-code-bundle": "<3.4.2",
                 "enhavo/enhavo-app": "<=0.13.1",
-                "enshrined/svg-sanitize": "<0.15",
+                "enshrined/svg-sanitize": "<0.22",
                 "erusev/parsedown": "<1.7.2",
                 "ether/logs": "<3.0.4",
                 "evolutioncms/evolution": "<=3.2.3",
@@ -2181,13 +2709,13 @@
                 "ezsystems/ezdemo-ls-extension": ">=5.4,<5.4.2.1-dev",
                 "ezsystems/ezfind-ls": ">=5.3,<5.3.6.1-dev|>=5.4,<5.4.11.1-dev|>=2017.12,<2017.12.0.1-dev",
                 "ezsystems/ezplatform": "<=1.13.6|>=2,<=2.5.24",
-                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.26|>=3.3,<3.3.39",
-                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1",
+                "ezsystems/ezplatform-admin-ui": ">=1.3,<1.3.5|>=1.4,<1.4.6|>=1.5,<1.5.29|>=2.3,<2.3.38|>=3.3,<3.3.39",
+                "ezsystems/ezplatform-admin-ui-assets": ">=4,<4.2.1|>=5,<5.0.1|>=5.1,<5.1.1|>=5.3.0.0-beta1,<5.3.5",
                 "ezsystems/ezplatform-graphql": ">=1.0.0.0-RC1-dev,<1.0.13|>=2.0.0.0-beta1,<2.3.12",
                 "ezsystems/ezplatform-http-cache": "<2.3.16",
                 "ezsystems/ezplatform-kernel": "<1.2.5.1-dev|>=1.3,<1.3.35",
                 "ezsystems/ezplatform-rest": ">=1.2,<=1.2.2|>=1.3,<1.3.8",
-                "ezsystems/ezplatform-richtext": ">=2.3,<2.3.7.1-dev|>=3.3,<3.3.40",
+                "ezsystems/ezplatform-richtext": ">=2.3,<2.3.26|>=3.3,<3.3.40",
                 "ezsystems/ezplatform-solr-search-engine": ">=1.7,<1.7.12|>=2,<2.0.2|>=3.3,<3.3.15",
                 "ezsystems/ezplatform-user": ">=1,<1.0.1",
                 "ezsystems/ezpublish-kernel": "<6.13.8.2-dev|>=7,<7.5.31",
@@ -2210,7 +2738,7 @@
                 "firebase/php-jwt": "<6",
                 "fisharebest/webtrees": "<=2.1.18",
                 "fixpunkt/fp-masterquiz": "<2.2.1|>=3,<3.5.2",
-                "fixpunkt/fp-newsletter": "<1.1.1|>=2,<2.1.2|>=2.2,<3.2.6",
+                "fixpunkt/fp-newsletter": "<1.1.1|>=1.2,<2.1.2|>=2.2,<3.2.6",
                 "flarum/core": "<1.8.10",
                 "flarum/flarum": "<0.1.0.0-beta8",
                 "flarum/framework": "<1.8.10",
@@ -2241,18 +2769,20 @@
                 "funadmin/funadmin": "<=5.0.2",
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
                 "genix/cms": "<=1.1.11",
+                "georgringer/news": "<1.3.3",
+                "geshi/geshi": "<=1.0.9.1",
                 "getformwork/formwork": "<1.13.1|>=2.0.0.0-beta1,<2.0.0.0-beta4",
                 "getgrav/grav": "<1.7.46",
-                "getkirby/cms": "<=3.6.6.5|>=3.7,<=3.7.5.4|>=3.8,<=3.8.4.3|>=3.9,<=3.9.8.1|>=3.10,<=3.10.1|>=4,<=4.3",
-                "getkirby/kirby": "<=2.5.12",
+                "getkirby/cms": "<3.9.8.3-dev|>=3.10,<3.10.1.2-dev|>=4,<4.7.1",
+                "getkirby/kirby": "<3.9.8.3-dev|>=3.10,<3.10.1.2-dev|>=4,<4.7.1",
                 "getkirby/panel": "<2.5.14",
                 "getkirby/starterkit": "<=3.7.0.2",
                 "gilacms/gila": "<=1.15.4",
                 "gleez/cms": "<=1.3|==2",
                 "globalpayments/php-sdk": "<2",
-                "goalgorilla/open_social": "<12.3.8|>=12.4,<12.4.5|>=13.0.0.0-alpha1,<13.0.0.0-alpha11",
+                "goalgorilla/open_social": "<12.3.11|>=12.4,<12.4.10|>=13.0.0.0-alpha1,<13.0.0.0-alpha11",
                 "gogentooss/samlbase": "<1.2.7",
-                "google/protobuf": "<3.15",
+                "google/protobuf": "<3.4",
                 "gos/web-socket-bundle": "<1.10.4|>=2,<2.6.1|>=3,<3.3",
                 "gree/jose": "<2.2.1",
                 "gregwar/rst": "<1.0.3",
@@ -2262,6 +2792,7 @@
                 "guzzlehttp/oauth-subscriber": "<0.8.1",
                 "guzzlehttp/psr7": "<1.9.1|>=2,<2.4.5",
                 "haffner/jh_captcha": "<=2.1.3|>=3,<=3.0.2",
+                "handcraftedinthealps/goodby-csv": "<1.4.3",
                 "harvesthq/chosen": "<1.8.7",
                 "helloxz/imgurl": "<=2.31",
                 "hhxsv5/laravel-s": "<3.7.36",
@@ -2271,9 +2802,10 @@
                 "hov/jobfair": "<1.0.13|>=2,<2.0.2",
                 "httpsoft/http-message": "<1.0.12",
                 "hyn/multi-tenant": ">=5.6,<5.7.2",
-                "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.14",
+                "ibexa/admin-ui": ">=4.2,<4.2.3|>=4.6,<4.6.21",
+                "ibexa/admin-ui-assets": ">=4.6.0.0-alpha1,<4.6.21",
                 "ibexa/core": ">=4,<4.0.7|>=4.1,<4.1.4|>=4.2,<4.2.3|>=4.5,<4.5.6|>=4.6,<4.6.2",
-                "ibexa/fieldtype-richtext": ">=4.6,<4.6.10",
+                "ibexa/fieldtype-richtext": ">=4.6,<4.6.21",
                 "ibexa/graphql": ">=2.5,<2.5.31|>=3.3,<3.3.28|>=4.2,<4.2.3",
                 "ibexa/http-cache": ">=4.6,<4.6.14",
                 "ibexa/post-install": "<1.0.16|>=4.6,<4.6.14",
@@ -2289,11 +2821,11 @@
                 "illuminate/view": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
                 "imdbphp/imdbphp": "<=5.1.1",
                 "impresscms/impresscms": "<=1.4.5",
-                "impresspages/impresspages": "<=1.0.12",
-                "in2code/femanager": "<5.5.3|>=6,<6.3.4|>=7,<7.2.3",
+                "impresspages/impresspages": "<1.0.13",
+                "in2code/femanager": "<6.4.2|>=7,<7.5.3|>=8,<8.3.1",
                 "in2code/ipandlanguageredirect": "<5.1.2",
                 "in2code/lux": "<17.6.1|>=18,<24.0.2",
-                "in2code/powermail": "<7.5.1|>=8,<8.5.1|>=9,<10.9.1|>=11,<12.4.1",
+                "in2code/powermail": "<7.5.1|>=8,<8.5.1|>=9,<10.9.1|>=11,<12.5.3|==13",
                 "innologi/typo3-appointments": "<2.0.6",
                 "intelliants/subrion": "<4.2.2",
                 "inter-mediator/inter-mediator": "==5.5",
@@ -2302,25 +2834,30 @@
                 "islandora/islandora": ">=2,<2.4.1",
                 "ivankristianto/phpwhois": "<=4.3",
                 "jackalope/jackalope-doctrine-dbal": "<1.7.4",
+                "jambagecom/div2007": "<0.10.2",
                 "james-heinrich/getid3": "<1.9.21",
-                "james-heinrich/phpthumb": "<1.7.12",
+                "james-heinrich/phpthumb": "<=1.7.23",
                 "jasig/phpcas": "<1.3.3",
+                "jbartels/wec-map": "<3.0.3",
                 "jcbrand/converse.js": "<3.3.3",
                 "joelbutcher/socialstream": "<5.6|>=6,<6.2",
-                "johnbillion/wp-crontrol": "<1.16.2",
+                "johnbillion/wp-crontrol": "<1.16.2|>=1.17,<1.19.2",
                 "joomla/application": "<1.0.13",
                 "joomla/archive": "<1.1.12|>=2,<2.0.1",
+                "joomla/database": ">=1,<2.2|>=3,<3.4",
                 "joomla/filesystem": "<1.6.2|>=2,<2.0.1",
                 "joomla/filter": "<1.4.4|>=2,<2.0.1",
                 "joomla/framework": "<1.5.7|>=2.5.4,<=3.8.12",
                 "joomla/input": ">=2,<2.0.2",
-                "joomla/joomla-cms": ">=2.5,<3.9.12",
+                "joomla/joomla-cms": "<3.9.12|>=4,<4.4.13|>=5,<5.2.6",
+                "joomla/joomla-platform": "<1.5.4",
                 "joomla/session": "<1.3.1",
                 "joyqi/hyper-down": "<=2.4.27",
                 "jsdecena/laracom": "<2.0.9",
                 "jsmitty12/phpwhois": "<5.1",
-                "juzaweb/cms": "<=3.4",
+                "juzaweb/cms": "<=3.4.2",
                 "jweiland/events2": "<8.3.8|>=9,<9.0.6",
+                "jweiland/kk-downloader": "<1.2.2",
                 "kazist/phpwhois": "<=4.2.6",
                 "kelvinmo/simplexrd": "<3.1.1",
                 "kevinpapst/kimai2": "<1.16.7",
@@ -2330,6 +2867,7 @@
                 "klaviyo/magento2-extension": ">=1,<3",
                 "knplabs/knp-snappy": "<=1.4.2",
                 "kohana/core": "<3.3.3",
+                "koillection/koillection": "<1.6.12",
                 "krayin/laravel-crm": "<=1.3",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
                 "kumbiaphp/kumbiapp": "<=1.1.1",
@@ -2348,7 +2886,7 @@
                 "latte/latte": "<2.10.8",
                 "lavalite/cms": "<=9|==10.1",
                 "lcobucci/jwt": ">=3.4,<3.4.6|>=4,<4.0.4|>=4.1,<4.1.5",
-                "league/commonmark": "<2.6",
+                "league/commonmark": "<2.7",
                 "league/flysystem": "<1.1.4|>=2,<2.1.1",
                 "league/oauth2-server": ">=8.3.2,<8.4.2|>=8.5,<8.5.3",
                 "leantime/leantime": "<3.3",
@@ -2359,14 +2897,16 @@
                 "lightsaml/lightsaml": "<1.3.5",
                 "limesurvey/limesurvey": "<6.5.12",
                 "livehelperchat/livehelperchat": "<=3.91",
-                "livewire/livewire": "<2.12.7|>=3.0.0.0-beta1,<3.5.2",
+                "livewire/livewire": "<2.12.7|>=3.0.0.0-beta1,<3.6.4",
                 "livewire/volt": "<1.7",
                 "lms/routes": "<2.1.1",
                 "localizationteam/l10nmgr": "<7.4|>=8,<8.7|>=9,<9.2",
+                "lomkit/laravel-rest-api": "<2.13",
+                "luracast/restler": "<3.1",
                 "luyadev/yii-helpers": "<1.2.1",
                 "macropay-solutions/laravel-crud-wizard-free": "<3.4.17",
                 "maestroerror/php-heic-to-jpg": "<1.0.5",
-                "magento/community-edition": "<2.4.5|==2.4.5|>=2.4.5.0-patch1,<2.4.5.0-patch11|==2.4.6|>=2.4.6.0-patch1,<2.4.6.0-patch9|>=2.4.7.0-beta1,<2.4.7.0-patch4|>=2.4.8.0-beta1,<2.4.8.0-beta2",
+                "magento/community-edition": "<2.4.5.0-patch14|==2.4.6|>=2.4.6.0-patch1,<2.4.6.0-patch12|>=2.4.7.0-beta1,<2.4.7.0-patch7|>=2.4.8.0-beta1,<2.4.8.0-patch1",
                 "magento/core": "<=1.9.4.5",
                 "magento/magento1ce": "<1.9.4.3-dev",
                 "magento/magento1ee": ">=1,<1.14.4.3-dev",
@@ -2375,10 +2915,13 @@
                 "magneto/core": "<1.9.4.4-dev",
                 "maikuolan/phpmussel": ">=1,<1.6",
                 "mainwp/mainwp": "<=4.4.3.3",
+                "manogi/nova-tiptap": "<=3.2.6",
                 "mantisbt/mantisbt": "<=2.26.3",
                 "marcwillmann/turn": "<0.3.3",
+                "marshmallow/nova-tiptap": "<5.7",
+                "matomo/matomo": "<1.11",
                 "matyhtf/framework": "<3.0.6",
-                "mautic/core": "<5.2.3",
+                "mautic/core": "<5.2.8|>=6.0.0.0-alpha,<6.0.5",
                 "mautic/core-lib": ">=1.0.0.0-beta,<4.4.13|>=5.0.0.0-alpha,<5.1.1",
                 "maximebf/debugbar": "<1.19",
                 "mdanter/ecc": "<2",
@@ -2388,6 +2931,7 @@
                 "mediawiki/data-transfer": ">=1.39,<1.39.11|>=1.41,<1.41.3|>=1.42,<1.42.2",
                 "mediawiki/matomo": "<2.4.3",
                 "mediawiki/semantic-media-wiki": "<4.0.2",
+                "mehrwert/phpmyadmin": "<3.2",
                 "melisplatform/melis-asset-manager": "<5.0.1",
                 "melisplatform/melis-cms": "<5.0.1",
                 "melisplatform/melis-front": "<5.0.1",
@@ -2396,7 +2940,7 @@
                 "microsoft/microsoft-graph": ">=1.16,<1.109.1|>=2,<2.0.1",
                 "microsoft/microsoft-graph-beta": "<2.0.1",
                 "microsoft/microsoft-graph-core": "<2.0.2",
-                "microweber/microweber": "<=2.0.16",
+                "microweber/microweber": "<=2.0.19",
                 "mikehaertl/php-shellcommand": "<1.6.1",
                 "miniorange/miniorange-saml": "<1.4.3",
                 "mittwald/typo3_forum": "<1.2.1",
@@ -2405,7 +2949,8 @@
                 "mojo42/jirafeau": "<4.4",
                 "mongodb/mongodb": ">=1,<1.9.2",
                 "monolog/monolog": ">=1.8,<1.12",
-                "moodle/moodle": "<4.3.10|>=4.4,<4.4.6|>=4.5.0.0-beta,<4.5.2",
+                "moodle/moodle": "<4.3.12|>=4.4,<4.4.8|>=4.5.0.0-beta,<4.5.4",
+                "moonshine/moonshine": "<=3.12.5",
                 "mos/cimage": "<0.7.19",
                 "movim/moxl": ">=0.8,<=0.10",
                 "movingbytes/social-network": "<=1.2.1",
@@ -2419,6 +2964,7 @@
                 "mustache/mustache": ">=2,<2.14.1",
                 "mwdelaney/wp-enable-svg": "<=0.2",
                 "namshi/jose": "<2.2",
+                "nasirkhan/laravel-starter": "<11.11",
                 "nategood/httpful": "<1",
                 "neoan3-apps/template": "<1.1.1",
                 "neorazorx/facturascripts": "<2022.04",
@@ -2433,6 +2979,7 @@
                 "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
                 "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
                 "nilsteampassnet/teampass": "<3.1.3.1-dev",
+                "nitsan/ns-backup": "<13.0.1",
                 "nonfiction/nterchange": "<4.1.1",
                 "notrinos/notrinos-erp": "<=0.7",
                 "noumo/easyii": "<=0.9",
@@ -2444,9 +2991,10 @@
                 "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
                 "october/backend": "<1.1.2",
                 "october/cms": "<1.0.469|==1.0.469|==1.0.471|==1.1.1",
-                "october/october": "<=3.6.4",
+                "october/october": "<3.7.5",
                 "october/rain": "<1.0.472|>=1.1,<1.1.2",
-                "october/system": "<1.0.476|>=1.1,<1.1.12|>=2,<2.2.34|>=3,<3.5.15",
+                "october/system": "<3.7.5",
+                "oliverklee/phpunit": "<3.5.15",
                 "omeka/omeka-s": "<4.0.3",
                 "onelogin/php-saml": "<2.10.4",
                 "oneup/uploader-bundle": ">=1,<1.9.3|>=2,<2.1.5",
@@ -2464,7 +3012,7 @@
                 "oro/customer-portal": ">=4.1,<=4.1.13|>=4.2,<=4.2.10|>=5,<=5.0.11|>=5.1,<=5.1.3",
                 "oro/platform": ">=1.7,<1.7.4|>=3.1,<3.1.29|>=4.1,<4.1.17|>=4.2,<=4.2.10|>=5,<=5.0.12|>=5.1,<=5.1.3",
                 "oveleon/contao-cookiebar": "<1.16.3|>=2,<2.1.3",
-                "oxid-esales/oxideshop-ce": "<4.5",
+                "oxid-esales/oxideshop-ce": "<=7.0.5",
                 "oxid-esales/paymorrow-module": ">=1,<1.0.2|>=2,<2.0.1",
                 "packbackbooks/lti-1-3-php-library": "<5",
                 "padraic/humbug_get_contents": "<1.1.2",
@@ -2480,6 +3028,7 @@
                 "pear/archive_tar": "<1.4.14",
                 "pear/auth": "<1.2.4",
                 "pear/crypt_gpg": "<1.6.7",
+                "pear/http_request2": "<2.7",
                 "pear/pear": "<=1.10.1",
                 "pegasus/google-for-jobs": "<1.5.1|>=2,<2.1.1",
                 "personnummer/personnummer": "<3.0.2",
@@ -2495,8 +3044,9 @@
                 "phpmyadmin/phpmyadmin": "<5.2.2",
                 "phpmyfaq/phpmyfaq": "<3.2.5|==3.2.5|>=3.2.10,<=4.0.1",
                 "phpoffice/common": "<0.2.9",
+                "phpoffice/math": "<=0.2",
                 "phpoffice/phpexcel": "<=1.8.2",
-                "phpoffice/phpspreadsheet": "<1.29.9|>=2,<2.1.8|>=2.2,<2.3.7|>=3,<3.9",
+                "phpoffice/phpspreadsheet": "<1.30|>=2,<2.1.12|>=2.2,<2.4|>=3,<3.10|>=4,<5",
                 "phpseclib/phpseclib": "<2.0.47|>=3,<3.0.36",
                 "phpservermon/phpservermon": "<3.6",
                 "phpsysinfo/phpsysinfo": "<3.4.3",
@@ -2505,7 +3055,7 @@
                 "phpxmlrpc/extras": "<0.6.1",
                 "phpxmlrpc/phpxmlrpc": "<4.9.2",
                 "pi/pi": "<=2.5",
-                "pimcore/admin-ui-classic-bundle": "<1.7.4",
+                "pimcore/admin-ui-classic-bundle": "<1.7.6",
                 "pimcore/customer-management-framework-bundle": "<4.2.1",
                 "pimcore/data-hub": "<1.2.4",
                 "pimcore/data-importer": "<1.8.9|>=1.9,<1.9.3",
@@ -2513,10 +3063,11 @@
                 "pimcore/ecommerce-framework-bundle": "<1.0.10",
                 "pimcore/perspective-editor": "<1.5.1",
                 "pimcore/pimcore": "<11.5.4",
-                "pixelfed/pixelfed": "<0.11.11",
+                "piwik/piwik": "<1.11",
+                "pixelfed/pixelfed": "<0.12.5",
                 "plotly/plotly.js": "<2.25.2",
                 "pocketmine/bedrock-protocol": "<8.0.2",
-                "pocketmine/pocketmine-mp": "<5.25.2",
+                "pocketmine/pocketmine-mp": "<5.32.1",
                 "pocketmine/raklib": ">=0.14,<0.14.6|>=0.15,<0.15.1",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
@@ -2524,7 +3075,7 @@
                 "prestashop/blockwishlist": ">=2,<2.1.1",
                 "prestashop/contactform": ">=1.0.1,<4.3",
                 "prestashop/gamification": "<2.3.2",
-                "prestashop/prestashop": "<8.1.6",
+                "prestashop/prestashop": "<8.2.3",
                 "prestashop/productcomments": "<5.0.2",
                 "prestashop/ps_contactinfo": "<=3.3.2",
                 "prestashop/ps_emailsubscription": "<2.6.1",
@@ -2534,10 +3085,11 @@
                 "processwire/processwire": "<=3.0.229",
                 "propel/propel": ">=2.0.0.0-alpha1,<=2.0.0.0-alpha7",
                 "propel/propel1": ">=1,<=1.7.1",
-                "pterodactyl/panel": "<1.11.8",
+                "pterodactyl/panel": "<=1.11.10",
                 "ptheofan/yii2-statemachine": ">=2.0.0.0-RC1-dev,<=2",
                 "ptrofimov/beanstalk_console": "<1.7.14",
                 "pubnub/pubnub": "<6.1",
+                "punktde/pt_extbase": "<1.5.1",
                 "pusher/pusher-php-server": "<2.2.1",
                 "pwweb/laravel-core": "<=0.3.6.0-beta",
                 "pxlrbt/filament-excel": "<1.1.14|>=2.0.0.0-alpha,<2.3.3",
@@ -2553,11 +3105,13 @@
                 "really-simple-plugins/complianz-gdpr": "<6.4.2",
                 "redaxo/source": "<5.18.3",
                 "remdex/livehelperchat": "<4.29",
+                "renolit/reint-downloadmanager": "<4.0.2|>=5,<5.0.1",
                 "reportico-web/reportico": "<=8.1",
                 "rhukster/dom-sanitizer": "<1.0.7",
                 "rmccue/requests": ">=1.6,<1.8",
                 "robrichards/xmlseclibs": ">=1,<3.0.4",
                 "roots/soil": "<4.1",
+                "roundcube/roundcubemail": "<1.5.10|>=1.6,<1.6.11",
                 "rudloff/alltube": "<3.0.3",
                 "rudloff/rtmpdump-bin": "<=2.3.1",
                 "s-cart/core": "<6.9",
@@ -2568,14 +3122,15 @@
                 "scheb/two-factor-bundle": "<3.26|>=4,<4.11",
                 "sensiolabs/connect": "<4.2.3",
                 "serluck/phpwhois": "<=4.2.6",
+                "setasign/fpdi": "<2.6.4",
                 "sfroemken/url_redirect": "<=1.2.1",
                 "sheng/yiicms": "<1.2.1",
-                "shopware/core": "<=6.5.8.12|>=6.6,<=6.6.5",
-                "shopware/platform": "<=6.5.8.12|>=6.6,<=6.6.5",
+                "shopware/core": "<6.5.8.18-dev|>=6.6,<6.6.10.3-dev|>=6.7.0.0-RC1-dev,<6.7.0.0-RC2-dev",
+                "shopware/platform": "<=6.6.10.4|>=6.7.0.0-RC1-dev,<6.7.0.0-RC2-dev",
                 "shopware/production": "<=6.3.5.2",
                 "shopware/shopware": "<=5.7.17",
                 "shopware/storefront": "<=6.4.8.1|>=6.5.8,<6.5.8.7-dev",
-                "shopxo/shopxo": "<=6.1",
+                "shopxo/shopxo": "<=6.4",
                 "showdoc/showdoc": "<2.10.4",
                 "shuchkin/simplexlsx": ">=1.0.12,<1.1.13",
                 "silverstripe-australia/advancedreports": ">=1,<=2",
@@ -2584,7 +3139,7 @@
                 "silverstripe/cms": "<4.11.3",
                 "silverstripe/comments": ">=1.3,<3.1.1",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-                "silverstripe/framework": "<5.3.8",
+                "silverstripe/framework": "<5.3.23",
                 "silverstripe/graphql": ">=2,<2.0.5|>=3,<3.8.2|>=4,<4.3.7|>=5,<5.1.3",
                 "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
                 "silverstripe/recipe-cms": ">=4.5,<4.5.3",
@@ -2596,6 +3151,7 @@
                 "silverstripe/taxonomy": ">=1.3,<1.3.1|>=2,<2.0.1",
                 "silverstripe/userforms": "<3|>=5,<5.4.2",
                 "silverstripe/versioned-admin": ">=1,<1.11.1",
+                "simogeo/filemanager": "<=2.5",
                 "simple-updates/phpwhois": "<=1",
                 "simplesamlphp/saml2": "<=4.16.15|>=5.0.0.0-alpha1,<=5.0.0.0-alpha19",
                 "simplesamlphp/saml2-legacy": "<=4.16.15",
@@ -2607,14 +3163,18 @@
                 "simplesamlphp/xml-security": "==1.6.11",
                 "simplito/elliptic-php": "<1.0.6",
                 "sitegeist/fluid-components": "<3.5",
+                "sjbr/sr-feuser-register": "<2.6.2|>=5.1,<12.5",
                 "sjbr/sr-freecap": "<2.4.6|>=2.5,<2.5.3",
+                "sjbr/static-info-tables": "<2.3.1",
                 "slim/psr7": "<1.4.1|>=1.5,<1.5.1|>=1.6,<1.6.1",
                 "slim/slim": "<2.6",
                 "slub/slub-events": "<3.0.3",
                 "smarty/smarty": "<4.5.3|>=5,<5.1.1",
-                "snipe/snipe-it": "<=7.0.13",
+                "snipe/snipe-it": "<8.1",
                 "socalnick/scn-social-auth": "<1.15.2",
                 "socialiteproviders/steam": "<1.1",
+                "solspace/craft-freeform": ">=5,<5.10.16",
+                "soosyze/soosyze": "<=2",
                 "spatie/browsershot": "<5.0.5",
                 "spatie/image-optimizer": "<1.7.3",
                 "spencer14420/sp-php-email-handler": "<1",
@@ -2623,8 +3183,9 @@
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
                 "ssddanbrown/bookstack": "<24.05.1",
-                "starcitizentools/citizen-skin": ">=2.6.3,<2.31",
-                "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2",
+                "starcitizentools/citizen-skin": ">=1.9.4,<3.4",
+                "starcitizentools/short-description": ">=4,<4.0.1",
+                "starcitizentools/tabber-neue": ">=1.9.1,<2.7.2|>=3,<3.1.1",
                 "statamic/cms": "<=5.16",
                 "stormpath/sdk": "<9.9.99",
                 "studio-42/elfinder": "<=2.1.64",
@@ -2632,9 +3193,10 @@
                 "subhh/libconnect": "<7.0.8|>=8,<8.1",
                 "sukohi/surpass": "<1",
                 "sulu/form-bundle": ">=2,<2.5.3",
-                "sulu/sulu": "<1.6.44|>=2,<2.5.21|>=2.6,<2.6.5",
+                "sulu/sulu": "<1.6.44|>=2,<2.5.25|>=2.6,<2.6.9|>=3.0.0.0-alpha1,<3.0.0.0-alpha3",
                 "sumocoders/framework-user-bundle": "<1.4",
                 "superbig/craft-audit": "<3.0.2",
+                "svewap/a21glossary": "<=0.4.10",
                 "swag/paypal": "<5.4.4",
                 "swiftmailer/swiftmailer": "<6.2.5",
                 "swiftyedit/swiftyedit": "<1.2",
@@ -2678,6 +3240,8 @@
                 "symfony/translation": ">=2,<2.0.17",
                 "symfony/twig-bridge": ">=2,<4.4.51|>=5,<5.4.31|>=6,<6.3.8",
                 "symfony/ux-autocomplete": "<2.11.2",
+                "symfony/ux-live-component": "<2.25.1",
+                "symfony/ux-twig-component": "<2.25.1",
                 "symfony/validator": "<5.4.43|>=6,<6.4.11|>=7,<7.1.4",
                 "symfony/var-exporter": ">=4.2,<4.2.12|>=4.3,<4.3.8",
                 "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
@@ -2715,13 +3279,14 @@
                 "twbs/bootstrap": "<=3.4.1|>=4,<=4.6.2",
                 "twig/twig": "<3.11.2|>=3.12,<3.14.1|>=3.16,<3.19",
                 "typo3/cms": "<9.5.29|>=10,<10.4.35|>=11,<11.5.23|>=12,<12.2",
-                "typo3/cms-backend": "<4.1.14|>=4.2,<4.2.15|>=4.3,<4.3.7|>=4.4,<4.4.4|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<10.4.46|>=11,<11.5.40|>=12,<12.4.21|>=13,<13.3.1",
+                "typo3/cms-backend": "<4.1.14|>=4.2,<4.2.15|>=4.3,<4.3.7|>=4.4,<4.4.4|>=7,<=7.6.50|>=8,<=8.7.39|>=9,<=9.5.24|>=10,<10.4.46|>=11,<11.5.40|>=12,<=12.4.30|>=13,<=13.4.11",
                 "typo3/cms-belog": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-beuser": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
-                "typo3/cms-core": "<=8.7.56|>=9,<=9.5.48|>=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-core": "<=8.7.56|>=9,<=9.5.50|>=10,<=10.4.49|>=11,<=11.5.43|>=12,<=12.4.30|>=13,<=13.4.11",
                 "typo3/cms-dashboard": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-extbase": "<6.2.24|>=7,<7.6.8|==8.1.1",
                 "typo3/cms-extensionmanager": ">=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
+                "typo3/cms-felogin": ">=4.2,<4.2.3",
                 "typo3/cms-fluid": "<4.3.4|>=4.4,<4.4.1",
                 "typo3/cms-form": ">=8,<=8.7.39|>=9,<=9.5.24|>=10,<=10.4.47|>=11,<=11.5.41|>=12,<=12.4.24|>=13,<=13.4.2",
                 "typo3/cms-frontend": "<4.3.9|>=4.4,<4.4.5",
@@ -2730,6 +3295,8 @@
                 "typo3/cms-lowlevel": ">=11,<=11.5.41",
                 "typo3/cms-rte-ckeditor": ">=9.5,<9.5.42|>=10,<10.4.39|>=11,<11.5.30",
                 "typo3/cms-scheduler": ">=11,<=11.5.41",
+                "typo3/cms-setup": ">=9,<=9.5.50|>=10,<=10.4.49|>=11,<=11.5.43|>=12,<=12.4.30|>=13,<=13.4.11",
+                "typo3/cms-webhooks": ">=12,<=12.4.30|>=13,<=13.4.11",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.12|>=3.1,<3.1.10|>=3.2,<3.2.13|>=3.3,<3.3.13|>=4,<4.0.6",
                 "typo3/html-sanitizer": ">=1,<=1.5.2|>=2,<=2.1.3",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4|>=2.3,<2.3.99|>=3,<3.0.20|>=3.1,<3.1.18|>=3.2,<3.2.14|>=3.3,<3.3.23|>=4,<4.0.17|>=4.1,<4.1.16|>=4.2,<4.2.12|>=4.3,<4.3.3",
@@ -2739,28 +3306,32 @@
                 "ua-parser/uap-php": "<3.8",
                 "uasoft-indonesia/badaso": "<=2.9.7",
                 "unisharp/laravel-filemanager": "<2.9.1",
-                "unopim/unopim": "<0.1.5",
+                "universal-omega/dynamic-page-list3": "<3.6.4",
+                "unopim/unopim": "<=0.3",
                 "userfrosting/userfrosting": ">=0.3.1,<4.6.3",
                 "usmanhalalit/pixie": "<1.0.3|>=2,<2.0.2",
                 "uvdesk/community-skeleton": "<=1.1.1",
                 "uvdesk/core-framework": "<=1.1.1",
                 "vanilla/safecurl": "<0.9.2",
                 "verbb/comments": "<1.5.5",
-                "verbb/formie": "<2.1.6",
+                "verbb/formie": "<=2.1.43",
                 "verbb/image-resizer": "<2.0.9",
                 "verbb/knock-knock": "<1.2.8",
                 "verot/class.upload.php": "<=2.1.6",
+                "vertexvaar/falsftp": "<0.2.6",
                 "villagedefrance/opencart-overclocked": "<=1.11.1",
                 "vova07/yii2-fileapi-widget": "<0.1.9",
-                "vrana/adminer": "<4.8.1",
+                "vrana/adminer": "<=4.8.1",
                 "vufind/vufind": ">=2,<9.1.1",
                 "waldhacker/hcaptcha": "<2.1.2",
                 "wallabag/tcpdf": "<6.2.22",
-                "wallabag/wallabag": "<2.6.7",
+                "wallabag/wallabag": "<2.6.11",
                 "wanglelecc/laracms": "<=1.0.3",
+                "wapplersystems/a21glossary": "<=0.4.10",
                 "web-auth/webauthn-framework": ">=3.3,<3.3.4|>=4.5,<4.9",
                 "web-auth/webauthn-lib": ">=4.5,<4.9",
                 "web-feet/coastercms": "==5.5",
+                "web-tp3/wec_map": "<3.0.3",
                 "webbuilders-group/silverstripe-kapost-bridge": "<0.4",
                 "webcoast/deferred-image-processing": "<1.0.2",
                 "webklex/laravel-imap": "<5.3",
@@ -2786,23 +3357,24 @@
                 "xataface/xataface": "<3",
                 "xpressengine/xpressengine": "<3.0.15",
                 "yab/quarx": "<2.4.5",
-                "yeswiki/yeswiki": "<=4.4.5",
+                "yeswiki/yeswiki": "<4.5.4",
                 "yetiforce/yetiforce-crm": "<6.5",
                 "yidashi/yii2cmf": "<=2",
                 "yii2mod/yii2-cms": "<1.9.2",
-                "yiisoft/yii": "<1.1.29",
-                "yiisoft/yii2": "<2.0.49.4-dev",
+                "yiisoft/yii": "<1.1.31",
+                "yiisoft/yii2": "<2.0.52",
                 "yiisoft/yii2-authclient": "<2.2.15",
                 "yiisoft/yii2-bootstrap": "<2.0.4",
                 "yiisoft/yii2-dev": "<=2.0.45",
                 "yiisoft/yii2-elasticsearch": "<2.0.5",
                 "yiisoft/yii2-gii": "<=2.2.4",
                 "yiisoft/yii2-jui": "<2.0.4",
-                "yiisoft/yii2-redis": "<2.0.8",
+                "yiisoft/yii2-redis": "<2.0.20",
                 "yikesinc/yikes-inc-easy-mailchimp-extender": "<6.8.6",
                 "yoast-seo-for-typo3/yoast_seo": "<7.2.3",
                 "yourls/yourls": "<=1.8.2",
                 "yuan1994/tpadmin": "<=1.3.12",
+                "z-push/z-push-dev": "<2.7.6",
                 "zencart/zencart": "<=1.5.7.0-beta",
                 "zendesk/zendesk_api_client_php": "<2.2.11",
                 "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
@@ -2877,24 +3449,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-24T22:04:54+00:00"
+            "time": "2025-09-04T20:05:35+00:00"
         },
         {
             "name": "roots/wordpress",
-            "version": "6.6.2",
+            "version": "6.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/wordpress.git",
-                "reference": "1bdabdb9171ac5323edbf4792ce353d475467d27"
+                "reference": "29e4eb49b2f4c591e39d4eb6705a27cf1ea40e45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roots/wordpress/zipball/1bdabdb9171ac5323edbf4792ce353d475467d27",
-                "reference": "1bdabdb9171ac5323edbf4792ce353d475467d27",
+                "url": "https://api.github.com/repos/roots/wordpress/zipball/29e4eb49b2f4c591e39d4eb6705a27cf1ea40e45",
+                "reference": "29e4eb49b2f4c591e39d4eb6705a27cf1ea40e45",
                 "shasum": ""
             },
             "require": {
-                "roots/wordpress-core-installer": "^1.0.0",
+                "roots/wordpress-core-installer": "^3.0",
                 "roots/wordpress-no-content": "self.version"
             },
             "type": "metapackage",
@@ -2912,7 +3484,7 @@
             ],
             "support": {
                 "issues": "https://github.com/roots/wordpress/issues",
-                "source": "https://github.com/roots/wordpress/tree/6.6.2"
+                "source": "https://github.com/roots/wordpress/tree/6.8.2"
             },
             "funding": [
                 {
@@ -2920,25 +3492,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-16T12:03:00+00:00"
+            "time": "2025-05-23T18:54:22+00:00"
         },
         {
             "name": "roots/wordpress-core-installer",
-            "version": "1.100.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/roots/wordpress-core-installer.git",
-                "reference": "73f8488e5178c5d54234b919f823a9095e2b1847"
+                "reference": "714d2e2a9e523f6e7bde4810d5a04aedf0ec217f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/roots/wordpress-core-installer/zipball/73f8488e5178c5d54234b919f823a9095e2b1847",
-                "reference": "73f8488e5178c5d54234b919f823a9095e2b1847",
+                "url": "https://api.github.com/repos/roots/wordpress-core-installer/zipball/714d2e2a9e523f6e7bde4810d5a04aedf0ec217f",
+                "reference": "714d2e2a9e523f6e7bde4810d5a04aedf0ec217f",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.6.0"
+                "php": ">=7.2.24"
             },
             "conflict": {
                 "composer/installers": "<1.0.6"
@@ -2948,7 +3520,7 @@
             },
             "require-dev": {
                 "composer/composer": "^1.0 || ^2.0",
-                "phpunit/phpunit": ">=5.7.27"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "composer-plugin",
             "extra": {
@@ -2973,44 +3545,41 @@
                     "email": "team@roots.io"
                 }
             ],
-            "description": "A custom installer to handle deploying WordPress with composer",
+            "description": "A Composer custom installer to handle installing WordPress as a dependency",
             "keywords": [
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/roots/wordpress-core-installer/issues",
-                "source": "https://github.com/roots/wordpress-core-installer/tree/master"
+                "source": "https://github.com/roots/wordpress-core-installer/tree/3.0.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/roots",
                     "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/rootsdev",
-                    "type": "patreon"
                 }
             ],
-            "time": "2020-08-20T00:27:30+00:00"
+            "time": "2025-05-23T18:47:25+00:00"
         },
         {
             "name": "roots/wordpress-no-content",
-            "version": "6.6.2",
+            "version": "6.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress.git",
-                "reference": "6.6.2"
+                "reference": "6.6.3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://downloads.wordpress.org/release/wordpress-6.6.2-no-content.zip",
-                "shasum": "b496b8a9bb3c6d20a781344cbe3e189f7fd83871"
+                "url": "https://downloads.w.org/release/wordpress-6.6.3-no-content.zip",
+                "reference": "6.6.3",
+                "shasum": "ec86d4b2a7f8cbe9b1cfc6136109263a644ad8e6"
             },
             "require": {
                 "php": ">= 7.2.24"
             },
             "provide": {
-                "wordpress/core-implementation": "6.6.2"
+                "wordpress/core-implementation": "6.6.3"
             },
             "suggest": {
                 "ext-curl": "Performs remote request operations.",
@@ -3061,7 +3630,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2024-09-10T15:25:31+00:00"
+            "time": "2025-08-05T19:05:35+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -3232,16 +3801,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.8",
+            "version": "4.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
                 "shasum": ""
             },
             "require": {
@@ -3294,15 +3863,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2022-09-14T12:41:17+00:00"
+            "time": "2025-08-10T06:51:50+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -3569,16 +4150,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.7",
+            "version": "5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9"
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
-                "reference": "bca7df1f32ee6fe93b4d4a9abbf69e13a4ada2c9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
                 "shasum": ""
             },
             "require": {
@@ -3621,15 +4202,27 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.7"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T06:35:11+00:00"
+            "time": "2025-08-10T07:10:35+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -3802,16 +4395,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "4.0.5",
+            "version": "4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
                 "shasum": ""
             },
             "require": {
@@ -3853,15 +4446,27 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T06:07:39+00:00"
+            "time": "2025-08-10T06:57:39+00:00"
         },
         {
             "name": "sebastian/resource-operations",
@@ -4028,16 +4633,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.12.0",
+            "version": "3.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630"
+                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
-                "reference": "2d1b63db139c3c6ea0c927698e5160f8b3b8d630",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
+                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
                 "shasum": ""
             },
             "require": {
@@ -4108,20 +4713,20 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-03-18T05:04:51+00:00"
+            "time": "2025-09-05T05:47:09+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.2.2",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "87a71856f2f56e4100373e92529eed3171695cfb"
+                "reference": "2a6614966ba1074fa93dae0bc804227422df4dfe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/87a71856f2f56e4100373e92529eed3171695cfb",
-                "reference": "87a71856f2f56e4100373e92529eed3171695cfb",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/2a6614966ba1074fa93dae0bc804227422df4dfe",
+                "reference": "2a6614966ba1074fa93dae0bc804227422df4dfe",
                 "shasum": ""
             },
             "require": {
@@ -4156,7 +4761,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.2.2"
+                "source": "https://github.com/symfony/finder/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -4168,15 +4773,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-30T19:00:17+00:00"
+            "time": "2025-07-15T13:41:35+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.31.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -4235,7 +4844,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4247,6 +4856,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -4255,19 +4868,20 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.31.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
+                "ext-iconv": "*",
                 "php": ">=7.2"
             },
             "provide": {
@@ -4315,7 +4929,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4327,15 +4941,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.31.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -4391,7 +5009,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4403,6 +5021,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -4411,16 +5033,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.31.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
                 "shasum": ""
             },
             "require": {
@@ -4471,7 +5093,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -4483,11 +5105,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-01-02T08:10:11+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -4775,27 +5401,27 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.6.3",
+            "version": "v2.6.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "065bb3758fcbff922f1b7a01ab702aab0da79803"
+                "reference": "5e73d417398993625331a9f69f6c2ef60f234070"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/065bb3758fcbff922f1b7a01ab702aab0da79803",
-                "reference": "065bb3758fcbff922f1b7a01ab702aab0da79803",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/5e73d417398993625331a9f69f6c2ef60f234070",
+                "reference": "5e73d417398993625331a9f69f6c2ef60f234070",
                 "shasum": ""
             },
             "require": {
                 "eftec/bladeone": "3.52",
                 "gettext/gettext": "^4.8",
                 "mck89/peast": "^1.13.11",
-                "wp-cli/wp-cli": "^2.5"
+                "wp-cli/wp-cli": "^2.12"
             },
             "require-dev": {
                 "wp-cli/scaffold-command": "^1.2 || ^2",
-                "wp-cli/wp-cli-tests": "^4"
+                "wp-cli/wp-cli-tests": "^4.3.9"
             },
             "suggest": {
                 "ext-json": "Used for reading and generating JSON translation files",
@@ -4838,9 +5464,61 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.6.3"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.6.5"
             },
-            "time": "2024-10-01T11:16:25+00:00"
+            "time": "2025-04-25T21:49:29+00:00"
+        },
+        {
+            "name": "wp-cli/mustache",
+            "version": "v2.14.99",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wp-cli/mustache.php.git",
+                "reference": "ca23b97ac35fbe01c160549eb634396183d04a59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wp-cli/mustache.php/zipball/ca23b97ac35fbe01c160549eb634396183d04a59",
+                "reference": "ca23b97ac35fbe01c160549eb634396183d04a59",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "replace": {
+                "mustache/mustache": "^2.14.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "~2.19.3",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Mustache": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Justin Hileman",
+                    "email": "justin@justinhileman.info",
+                    "homepage": "http://justinhileman.com"
+                }
+            ],
+            "description": "A Mustache implementation in PHP.",
+            "homepage": "https://github.com/bobthecow/mustache.php",
+            "keywords": [
+                "mustache",
+                "templating"
+            ],
+            "support": {
+                "source": "https://github.com/wp-cli/mustache.php/tree/v2.14.99"
+            },
+            "time": "2025-05-06T16:15:37+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -4895,20 +5573,20 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.22",
+            "version": "v0.12.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "a6bb94664ca36d0962f9c2ff25591c315a550c51"
+                "reference": "34b83b4f700df8a4ec3fd17bf7e7e7d8ca5f28da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/a6bb94664ca36d0962f9c2ff25591c315a550c51",
-                "reference": "a6bb94664ca36d0962f9c2ff25591c315a550c51",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/34b83b4f700df8a4ec3fd17bf7e7e7d8ca5f28da",
+                "reference": "34b83b4f700df8a4ec3fd17bf7e7e7d8ca5f28da",
                 "shasum": ""
             },
             "require": {
-                "php": ">= 5.3.0"
+                "php": ">= 5.6.0"
             },
             "require-dev": {
                 "roave/security-advisories": "dev-latest",
@@ -4952,39 +5630,38 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.22"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.12.5"
             },
-            "time": "2023-12-03T19:25:05+00:00"
+            "time": "2025-03-26T16:13:46+00:00"
         },
         {
             "name": "wp-cli/wp-cli",
-            "version": "v2.11.0",
+            "version": "v2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/wp-cli.git",
-                "reference": "53f0df112901fcf95099d0f501912a209429b6a9"
+                "reference": "03d30d4138d12b4bffd8b507b82e56e129e0523f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/53f0df112901fcf95099d0f501912a209429b6a9",
-                "reference": "53f0df112901fcf95099d0f501912a209429b6a9",
+                "url": "https://api.github.com/repos/wp-cli/wp-cli/zipball/03d30d4138d12b4bffd8b507b82e56e129e0523f",
+                "reference": "03d30d4138d12b4bffd8b507b82e56e129e0523f",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
-                "mustache/mustache": "^2.14.1",
                 "php": "^5.6 || ^7.0 || ^8.0",
                 "symfony/finder": ">2.7",
+                "wp-cli/mustache": "^2.14.99",
                 "wp-cli/mustangostang-spyc": "^0.6.3",
-                "wp-cli/php-cli-tools": "~0.11.2"
+                "wp-cli/php-cli-tools": "~0.12.4"
             },
             "require-dev": {
-                "roave/security-advisories": "dev-latest",
                 "wp-cli/db-command": "^1.3 || ^2",
                 "wp-cli/entity-command": "^1.2 || ^2",
                 "wp-cli/extension-command": "^1.1 || ^2",
                 "wp-cli/package-command": "^1 || ^2",
-                "wp-cli/wp-cli-tests": "^4.0.1"
+                "wp-cli/wp-cli-tests": "^4.3.10"
             },
             "suggest": {
                 "ext-readline": "Include for a better --prompt implementation",
@@ -4997,7 +5674,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.11.x-dev"
+                    "dev-main": "2.12.x-dev"
                 }
             },
             "autoload": {
@@ -5024,20 +5701,20 @@
                 "issues": "https://github.com/wp-cli/wp-cli/issues",
                 "source": "https://github.com/wp-cli/wp-cli"
             },
-            "time": "2024-08-08T03:04:55+00:00"
+            "time": "2025-05-07T01:16:12+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.1.0",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7"
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/9333efcbff231f10dfd9c56bb7b65818b4733ca7",
-                "reference": "9333efcbff231f10dfd9c56bb7b65818b4733ca7",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/d2421de7cec3274ae622c22c744de9a62c7925af",
+                "reference": "d2421de7cec3274ae622c22c744de9a62c7925af",
                 "shasum": ""
             },
             "require": {
@@ -5046,13 +5723,13 @@
                 "ext-tokenizer": "*",
                 "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "phpcsstandards/phpcsextra": "^1.2.1",
-                "phpcsstandards/phpcsutils": "^1.0.10",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "phpcsstandards/phpcsextra": "^1.4.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
@@ -5090,11 +5767,11 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-03-25T16:39:00+00:00"
+            "time": "2025-07-24T20:08:31+00:00"
         },
         {
             "name": "wp-phpunit/wp-phpunit",
-            "version": "6.6.2",
+            "version": "6.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-phpunit/wp-phpunit.git",
@@ -5142,16 +5819,16 @@
         },
         {
             "name": "yoast/phpunit-polyfills",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "a0e3e9adecaa352697786cb29bb0f2fcc25f43f5"
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/a0e3e9adecaa352697786cb29bb0f2fcc25f43f5",
-                "reference": "a0e3e9adecaa352697786cb29bb0f2fcc25f43f5",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
                 "shasum": ""
             },
             "require": {
@@ -5161,7 +5838,7 @@
             "require-dev": {
                 "php-parallel-lint/php-console-highlighter": "^1.0.0",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "yoast/yoastcs": "^3.1.0"
+                "yoast/yoastcs": "^3.2.0"
             },
             "type": "library",
             "extra": {
@@ -5201,12 +5878,13 @@
                 "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
                 "source": "https://github.com/Yoast/PHPUnit-Polyfills"
             },
-            "time": "2025-02-09T18:25:29+00:00"
+            "time": "2025-08-10T05:13:49+00:00"
         }
     ],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "pinkcrab/coding-standards": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/config/dependencies.php
+++ b/config/dependencies.php
@@ -8,4 +8,29 @@
  *
  * @return array<string, mixed>
  */
-return array();
+
+use PinkCrab\HTTP\HTTP_Helper;
+use Psr\Http\Message\ServerRequestInterface;
+use PinkCrab\Ecowitt_Weather_Block\Settings\Settings;
+use PinkCrab\Ecowitt_Weather_Block\Settings\Settings_Repository;
+use PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections;
+
+return array(
+    '*' =>[
+        'substitutions' => [
+             Settings::class => array(
+                \Dice\Dice::INSTANCE => function(){
+                    // Get the connections from settings.
+                    $settings = new Settings_Repository();
+                    $saved = $settings->load();
+                    return $saved ?? new Settings( new Connections() );
+                }
+            ),
+            ServerRequestInterface::class => array(
+                \Dice\Dice::INSTANCE => function() {
+                    return HTTP_Helper::global_server_request();
+                }
+            ),
+        ],
+    ]
+);

--- a/config/registration.php
+++ b/config/registration.php
@@ -8,4 +8,8 @@
  *
  * @return array<class-string>
  */
-return array();
+
+return array(
+	\PinkCrab\Ecowitt_Weather_Block\Settings\Page\Settings_Page::class,
+	\PinkCrab\Ecowitt_Weather_Block\Admin\Asset_Loader::class,
+);

--- a/config/settings.php
+++ b/config/settings.php
@@ -8,4 +8,11 @@
  *
  * @return array<string, mixed>
  */
-return array();
+return array(
+	'url'  => array(
+		'assets' => plugins_url( '/', __DIR__ ) . 'assets/build/',
+	),
+	'path' => array(
+		'assets' => dirname( __DIR__, 1 ) . '/assets/build/',
+	),
+);

--- a/ecowitt-weather-block.php
+++ b/ecowitt-weather-block.php
@@ -26,6 +26,7 @@ defined( 'ABSPATH' ) || exit;
 
 
 use PinkCrab\Perique\Application\App_Factory;
+use PinkCrab\Perique_Admin_Menu\Module\Admin_Menu;
 
 require_once __DIR__ . '/vendor/autoload.php';
 
@@ -37,6 +38,7 @@ add_action(
 	function (): void {
 		$app = ( new App_Factory( __DIR__ ) )
             ->default_setup()
+            ->module( Admin_Menu::class )
             ->di_rules( require __DIR__ . '/config/dependencies.php' )
             ->app_config( require __DIR__ . '/config/settings.php' )
             ->registration_classes( require __DIR__ . '/config/registration.php' );

--- a/package.json
+++ b/package.json
@@ -49,14 +49,17 @@
     "scripts": {
         "build": "npm-run-all --sequential build:**",
         "build:blocks": "wp-scripts build --webpack-src-dir=./block/src --output-path=block/build",
-        "format:scripts": "wp-scripts format ./block/src --no-error-on-unmatched-pattern",
+        "build:admin-styles": "wp-scripts build ./assets/src/scss/admin.scss --output-path=assets/build/css",
+        "build:scripts": "npm run build:blocks && mkdir -p ./assets/build/js && cp ./assets/src/js/settings.js ./assets/build/js/settings.js && cp ./assets/src/js/dashboard.js ./assets/build/js/dashboard.js",
+        "start": "npm-run-all --parallel start:**",
+        "start:blocks": "wp-scripts start --webpack-src-dir=./block/src --output-path=block/build",
+        "start:admin-styles": "wp-scripts start ./assets/src/scss/admin.scss --output-path=assets/build/css",
+        "format:scripts": "wp-scripts format ./block/src ./assets/src/js/settings.js ./assets/src/js/dashboard.js --no-error-on-unmatched-pattern",
         "format:styles": "npm run lint:styles:./block/src -- --fix",
-        "lint:scripts": "wp-scripts lint-js ./ --no-error-on-unmatched-pattern",
+        "lint:scripts": "wp-scripts lint-js ./block/src ./assets/src/js/settings.js ./assets/src/js/dashboard.js --no-error-on-unmatched-pattern",
         "lint:styles": "wp-scripts lint-style ./**/*.{css,sass,scss} --allow-empty-input --report-descriptionless-disables --report-invalid-scope-disables --report-needless-disables",
         "packages-update": "wp-scripts packages-update",
         "check-engines": "wp-scripts check-engines",
-        "check-licenses": "wp-scripts check-licenses",
-        "start": "npm-run-all --parallel start:**",
-        "start:blocks": "wp-scripts start --webpack-src-dir=.block/src --output-path=block/build"
+        "check-licenses": "wp-scripts check-licenses"
     }
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,15 +1,32 @@
 <?xml version="1.0"?>
-<ruleset name="ecowitt-weather-block" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
-	<description>Custom ruleset for Ecowitt Weather Block plugin</description>
+<ruleset name="ecowitt-weather-block" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../vendor/squizlabs/php_codesniffer/phpcs.xsd">
+	<description>Custom ruleset for all PinkCrab blocks</description>
 
-	<!-- Extend the PinkCrab Standards ruleset. -->
-	<rule ref="./vendor/pinkcrab/coding-standards/PinkCrabStandards/ruleset.xml"/>
+	<!-- Include the WordPress-Extra standard. -->
+	<rule ref="WordPress-Extra">		
+		<exclude name="WordPress.Files.FileName.NotHyphenatedLowercase"/>
+		<exclude name="WordPress.Files.FileName.InvalidClassFileName"/>
+		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_getinfo"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_setopt"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_exec"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_init"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.curl_curl_close"/>
+		<exclude name="WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents"/>
+		<exclude name="WordPress.PHP.DisallowShortTernary.Found"/>
+		<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
+		<exclude name="PSR12.Files.FileHeader.IncorrectOrder" />
+	</rule>
+
+	<!-- Add in some extra rules from other standards. -->
+	<rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+	<rule ref="Generic.Commenting.Todo"/>
 
 	<!-- Check that the proper text domain(s) is used everywhere. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="ecowitt-weather-block"/> <!-- Updated to match your plugin slug -->
+				<element value="pinkcrab-weather-block"/> <!-- Change this value to your plugin slug. -->
 			</property>
 		</properties>
 	</rule>
@@ -18,16 +35,11 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">
-				<element value="PinkCrab"/>
-				<element value="Ecowitt_Weather_Block"/>
+				<element value="pinkcrab"/>
+				<element value="pc_weather"/>
 			</property>
 		</properties>
 	</rule>
 
-	<!-- Exclude test files from certain rules -->
-	<rule ref="Squiz.Commenting.FunctionComment.Missing">
-		<exclude-pattern>*/tests/*</exclude-pattern>
-	</rule>
-	
 	<!-- Add any other custom rules here. -->
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
-<ruleset name="ecowitt-weather-block" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../vendor/squizlabs/php_codesniffer/phpcs.xsd">
-	<description>Custom ruleset for all PinkCrab blocks</description>
+<ruleset name="ecowitt-weather-block" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="./vendor/squizlabs/php_codesniffer/phpcs.xsd">
+	<description>Custom ruleset for Ecowitt Weather Block plugin</description>
 
-	<!-- Extend the A8CTeam51 ruleset. -->
-	<rule ref="../../vendor/a8cteam51/team51-configs/quality-tools/phpcs.xml.dist"/>
+	<!-- Extend the PinkCrab Standards ruleset. -->
+	<rule ref="./vendor/pinkcrab/coding-standards/PinkCrabStandards/ruleset.xml"/>
 
 	<!-- Check that the proper text domain(s) is used everywhere. -->
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element value="pinkcrab-weather-block"/> <!-- Change this value to your plugin slug. -->
+				<element value="ecowitt-weather-block"/> <!-- Updated to match your plugin slug -->
 			</property>
 		</properties>
 	</rule>
@@ -18,11 +18,16 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">
-				<element value="pinkcrab"/>
-				<element value="pc_weather"/>
+				<element value="PinkCrab"/>
+				<element value="Ecowitt_Weather_Block"/>
 			</property>
 		</properties>
 	</rule>
 
+	<!-- Exclude test files from certain rules -->
+	<rule ref="Squiz.Commenting.FunctionComment.Missing">
+		<exclude-pattern>*/tests/*</exclude-pattern>
+	</rule>
+	
 	<!-- Add any other custom rules here. -->
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,7 +8,7 @@ parameters:
     inferPrivatePropertyTypeFromConstructor: true
     treatPhpDocTypesAsCertain: false
     paths:
-        - %currentWorkingDirectory%/includes/
+        - %currentWorkingDirectory%/src/
     excludePaths:
         - %currentWorkingDirectory%/tests/*
     bootstrapFiles:

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,17 +15,16 @@
         </testsuite>
     </testsuites>
 
-     <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./includes/</directory>
-        </whitelist>
-    </filter>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./src/</directory>
+        </include>
+        <report>
+            <clover outputFile="coverage-report/logs/clover.xml"/>
+        </report>
+    </coverage>
 
     <php>
         <env name="WP_PHPUNIT__TESTS_CONFIG" value="tests/wp-config.php" />
     </php>
-
-    <logging>
-        <log type="coverage-clover" target="coverage-report/logs/clover.xml"/>
-    </logging>
 </phpunit>

--- a/src/Admin/Asset_Loader.php
+++ b/src/Admin/Asset_Loader.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Admin Asset Loader
+ *
+ * Handles the loading of CSS and JS assets for the admin area.
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Admin;
+
+use PinkCrab\Enqueue\Enqueue;
+use PinkCrab\Perique\Interfaces\Hookable;
+use PinkCrab\Loader\Hook_Loader;
+
+class Asset_Loader implements Hookable {
+
+	/**
+	 * App_Config instance.
+	 *
+	 * @var \PinkCrab\Perique\Application\App_Config
+	 */
+	protected \PinkCrab\Perique\Application\App_Config $app_config;
+
+	public function __construct( \PinkCrab\Perique\Application\App_Config $app_config ) {
+		$this->app_config = $app_config;
+	}
+
+	/**
+	 * Register all hooks.
+	 *
+	 * @param Hook_Loader $loader
+	 * @return void
+	 */
+	public function register( Hook_Loader $loader ): void {
+		$loader->admin_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+	}
+
+	/**
+	 * Enqueue admin styles and scripts.
+	 *
+	 * @return void
+	 */
+	public function enqueue_assets(): void {
+		Enqueue::style( 'ecowitt-admin-styles' )
+			->src( $this->app_config->url( 'assets' ) . 'css/admin.scss.css' )
+			->ver( $this->app_config->version() )
+			->register();
+	}
+}

--- a/src/Admin/Asset_Loader.php
+++ b/src/Admin/Asset_Loader.php
@@ -13,6 +13,7 @@ namespace PinkCrab\Ecowitt_Weather_Block\Admin;
 use PinkCrab\Enqueue\Enqueue;
 use PinkCrab\Perique\Interfaces\Hookable;
 use PinkCrab\Loader\Hook_Loader;
+use PinkCrab\Perique\Application\Config;
 
 class Asset_Loader implements Hookable {
 
@@ -25,6 +26,18 @@ class Asset_Loader implements Hookable {
 
 	public function __construct( \PinkCrab\Perique\Application\App_Config $app_config ) {
 		$this->app_config = $app_config;
+	}
+
+	/**
+	 * Get assets url.
+	 *
+	 * @return string
+	 */
+	public static function assets_url(): string {
+		$assets = Config::url( 'assets' ); // @phpstan-ignore-line, this is a magic method.
+		return is_string( $assets )
+			? $assets
+			: wp_upload_dir()['baseurl'];
 	}
 
 	/**
@@ -44,7 +57,7 @@ class Asset_Loader implements Hookable {
 	 */
 	public function enqueue_assets(): void {
 		Enqueue::style( 'ecowitt-admin-styles' )
-			->src( $this->app_config->url( 'assets' ) . 'css/admin.scss.css' )
+			->src( self::assets_url() . '/css/admin.scss.css' )
 			->ver( $this->app_config->version() )
 			->register();
 	}

--- a/src/Admin/Notifications.php
+++ b/src/Admin/Notifications.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * Handles all admin notifications.
+ *
+ * @since 0.1.0
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Admin;
+
+/**
+ * Handles all admin notifications.
+ */
+class Notifications {
+
+	/**
+	 * Holds all notifications.
+	 *
+	 * @var array<int, array{type: string, message: string}>
+	 */
+	protected array $notifications = array();
+
+	/**
+	 * Adds a notification.
+	 *
+	 * @param string $type    The type of notification.
+	 * @param string $message The message to display.
+     * 
+	 * @return void
+	 */
+	public function add_notification( string $type, string $message ): void {
+		$this->notifications[] = array(
+			'type'    => $type,
+			'message' => $message,
+		);
+	}
+
+	/**
+	 * Add a success notification.
+	 *
+	 * @param string $message The message to display.
+     * 
+	 * @return void
+	 */
+	public function add_success( string $message ): void {
+		$this->add_notification( 'success', $message );
+	}
+
+	/**
+	 * Add an error notification.
+	 *
+	 * @param string $message The message to display.
+     *
+	 * @return void
+	 */
+	public function add_error( string $message ): void {
+		$this->add_notification( 'error', $message );
+	}
+
+	/**
+	 * Add an info notification.
+	 *
+	 * @param string $message The message to display.
+     *
+	 * @return void
+	 */
+	public function add_info( string $message ): void {
+		$this->add_notification( 'info', $message );
+	}
+
+	/**
+	 * Checks if there are any notifications.
+	 *
+	 * @return boolean
+	 */
+	public function has_notifications(): bool {
+		return ! empty( $this->notifications );
+	}
+
+	/**
+	 * Get all notifications.
+	 * 
+	 * @return array<int, array{type: string, message: string}>
+	 */
+	public function get_notifications(): array {
+		return $this->notifications;
+	}
+
+	/**
+	 * Render all notifications.
+	 *
+	 * @param boolean $is_dismissible If the notifications should be dismissible.
+     * 
+	 * @return void
+	 */
+	public function render_notifications( bool $is_dismissible = true ): void {
+		$notifications = $this->notifications;
+		$notifications = array_filter( $notifications, function( $n ) {
+			return ! empty( $n['message'] );
+		} );
+		if ( $this->has_notifications() ) {
+			foreach ( $notifications as $notification ) {
+				printf(
+					'<div class="notice notice-%1$s%2$s"><p>%3$s</p></div>',
+					esc_attr( $notification['type'] ),
+					$is_dismissible ? ' is-dismissible' : '',
+					esc_html( $notification['message'] )
+				);
+			}
+		}
+	}
+
+	/**
+	 * Clears all notifications.
+	 *
+	 * @return void
+	 */
+	public function clear_notifications(): void {
+		$this->notifications = array();
+	}
+}

--- a/src/Admin/Notifications.php
+++ b/src/Admin/Notifications.php
@@ -29,7 +29,7 @@ class Notifications {
 	 *
 	 * @param string $type    The type of notification.
 	 * @param string $message The message to display.
-     * 
+	 *
 	 * @return void
 	 */
 	public function add_notification( string $type, string $message ): void {
@@ -43,7 +43,7 @@ class Notifications {
 	 * Add a success notification.
 	 *
 	 * @param string $message The message to display.
-     * 
+	 *
 	 * @return void
 	 */
 	public function add_success( string $message ): void {
@@ -54,7 +54,7 @@ class Notifications {
 	 * Add an error notification.
 	 *
 	 * @param string $message The message to display.
-     *
+	 *
 	 * @return void
 	 */
 	public function add_error( string $message ): void {
@@ -65,7 +65,7 @@ class Notifications {
 	 * Add an info notification.
 	 *
 	 * @param string $message The message to display.
-     *
+	 *
 	 * @return void
 	 */
 	public function add_info( string $message ): void {
@@ -83,7 +83,7 @@ class Notifications {
 
 	/**
 	 * Get all notifications.
-	 * 
+	 *
 	 * @return array<int, array{type: string, message: string}>
 	 */
 	public function get_notifications(): array {
@@ -94,14 +94,17 @@ class Notifications {
 	 * Render all notifications.
 	 *
 	 * @param boolean $is_dismissible If the notifications should be dismissible.
-     * 
+	 *
 	 * @return void
 	 */
 	public function render_notifications( bool $is_dismissible = true ): void {
 		$notifications = $this->notifications;
-		$notifications = array_filter( $notifications, function( $n ) {
-			return ! empty( $n['message'] );
-		} );
+		$notifications = array_filter(
+			$notifications,
+			function ( $n ) {
+				return ! empty( $n['message'] );
+			}
+		);
 		if ( $this->has_notifications() ) {
 			foreach ( $notifications as $notification ) {
 				printf(

--- a/src/Ecowitt/Api/Connection/Connection.php
+++ b/src/Ecowitt/Api/Connection/Connection.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Holds an ecoiwtt API Connection.
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ *
+ * @since 0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection;
+
+use JsonSerializable;
+
+/**
+ * Holds an ecoiwtt API Connection.
+ */
+class Connection implements JsonSerializable {
+
+	/**
+	 * Holds the key.
+	 *
+	 * @var string
+	 */
+	protected string $key;
+
+	/**
+	 * Holds the API key.
+	 *
+	 * @var string
+	 */
+	protected string $api_key;
+
+	/**
+	 * Holds the API secret.
+	 *
+	 * @var string
+	 */
+	protected string $api_secret;
+
+	/**
+	 * Holds the MAC address.
+	 *
+	 * @var string
+	 */
+	protected string $mac_address;
+
+	/**
+	 * Connection Description.
+	 *
+	 * @var string
+	 */
+	protected string $description;
+
+	/**
+	 * Connection Name.
+	 *
+	 * @var string
+	 */
+	protected string $name;
+
+	/**
+	 * Creates an instance of the Credential.
+	 *
+	 * @param string $key         The key.
+	 * @param string $api_key     The API key.
+	 * @param string $api_secret  The API secret.
+	 * @param string $mac_address The MAC address.
+	 * @param string $description The description.
+	 * @param string $name        The name.
+	 */
+	public function __construct( string $key, string $api_key, string $api_secret, string $mac_address, string $description, string $name ) {
+		$this->key         = \esc_attr( $key );
+		$this->api_key     = \esc_attr( $api_key );
+		$this->api_secret  = \esc_attr( $api_secret );
+		$this->mac_address = \esc_attr( $mac_address );
+		$this->description = \esc_attr( $description );
+		$this->name        = \esc_attr( $name );
+	}
+
+	/**
+	 * Access to the key.
+	 *
+	 * @return string
+	 */
+	public function key(): string {
+		return $this->key;
+	}
+
+	/**
+	 * Access to the API key.
+	 *
+	 * @return string
+	 */
+	public function api_key(): string {
+		return $this->api_key;
+	}
+
+	/**
+	 * Access to the API secret.
+	 *
+	 * @return string
+	 */
+	public function api_secret(): string {
+		return $this->api_secret;
+	}
+
+	/**
+	 * Access to the MAC address.
+	 *
+	 * @return string
+	 */
+	public function mac_address(): string {
+		return $this->mac_address;
+	}
+
+	/**
+	 * Access to the description.
+	 *
+	 * @return string
+	 */
+	public function description(): string {
+		return $this->description;
+	}
+
+	/**
+	 * Access to the name.
+	 *
+	 * @return string
+	 */
+	public function name(): string {
+		return $this->name;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function jsonSerialize(): array {
+		return array(
+			'key'         => $this->key,
+			'api_key'     => $this->api_key,
+			'api_secret'  => $this->api_secret,
+			'mac_address' => $this->mac_address,
+			'description' => $this->description,
+			'name'        => $this->name,
+		);
+	}
+}

--- a/src/Ecowitt/Api/Connection/Connection.php
+++ b/src/Ecowitt/Api/Connection/Connection.php
@@ -135,7 +135,9 @@ class Connection implements JsonSerializable {
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Simple serialisation of the connection.
+	 *
+	 * @return array{key: string, api_key: string, api_secret: string, mac_address: string, description: string, name: string}
 	 */
 	public function jsonSerialize(): array {
 		return array(

--- a/src/Ecowitt/Api/Connection/Connections.php
+++ b/src/Ecowitt/Api/Connection/Connections.php
@@ -23,14 +23,14 @@ class Connections implements JsonSerializable {
 	/**
 	 * Holds the connection data.
 	 *
-	 * @var array<int, array{key: string, api_key: string, api_secret: string, mac_address: string}>
+	 * @var array<int, Connection>
 	 */
 	protected array $connections = array();
 
 	/**
 	 * Create a new instance of the connections.
 	 *
-	 * @param array<int, Connection> $connections
+	 * @param array<int, mixed> $connections
 	 */
 	public function __construct( array $connections = array() ) {
 		$this->connections = array_filter( $connections, fn( $connection ) => $connection instanceof Connection );
@@ -39,7 +39,7 @@ class Connections implements JsonSerializable {
 	/**
 	 * Creates an instance of the Connections from arrays
 	 *
-	 * @param array<int, array{key: string, api_key: string, api_secret: string, mac_address: string, ?de}> $connections
+	 * @param array<int|string, array{key: string, api_key: string, api_secret: string, mac_address: string, description: string, name: string}|mixed> $connections
 	 *
 	 * @return self
 	 */
@@ -59,16 +59,19 @@ class Connections implements JsonSerializable {
 				}
 
 				return new Connection(
-					esc_attr( $data['key'] ),
-					esc_attr( $data['api_key'] ),
-					esc_attr( $data['api_secret'] ),
-					esc_attr( $data['mac_address'] ),
-					isset( $data['description'] ) ? esc_attr( $data['description'] ) : '',
-					isset( $data['name'] ) ? esc_attr( $data['name'] ) : ''
+					esc_attr( is_string( $data['key'] ) ? $data['key'] : '' ),
+					esc_attr( is_string( $data['api_key'] ) ? $data['api_key'] : '' ),
+					esc_attr( is_string( $data['api_secret'] ) ? $data['api_secret'] : '' ),
+					esc_attr( is_string( $data['mac_address'] ) ? $data['mac_address'] : '' ),
+					isset( $data['description'] ) ? esc_attr( is_string( $data['description'] ) ? $data['description'] : '' ) : '',
+					isset( $data['name'] ) ? esc_attr( is_string( $data['name'] ) ? $data['name'] : '' ) : ''
 				);
 			},
 			$connections
 		);
+
+		// Remove any null values.
+		$connections = array_values( array_filter( $connections ) );
 
 		return new self( $connections );
 	}
@@ -142,7 +145,7 @@ class Connections implements JsonSerializable {
 	/**
 	 * Gets all connections.
 	 *
-	 * @return array<int, array{key: string, api_key: string, api_secret: string, mac_address: string}>
+	 * @return array<int, Connection>
 	 */
 	public function all(): array {
 		return $this->connections;
@@ -163,9 +166,9 @@ class Connections implements JsonSerializable {
 	}
 
 	/**
-	 * Returns the settings as an array.
+	 * Returns the connections as an array for JSON serialization.
 	 *
-	 * @return array<int, array{key: string, api_key: string, api_secret: string, mac_address: string, description: string, name: string}>
+	 * @return array<int, Connection>
 	 */
 	public function jsonSerialize(): array {
 		return $this->connections;

--- a/src/Ecowitt/Api/Connection/Connections.php
+++ b/src/Ecowitt/Api/Connection/Connections.php
@@ -1,0 +1,173 @@
+<?php
+
+/**
+ * Holds the connection data.
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ *
+ * @since 0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection;
+
+use PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection;
+use JsonSerializable;
+
+/**
+ * Holds the connection data.
+ */
+class Connections implements JsonSerializable {
+
+	/**
+	 * Holds the connection data.
+	 *
+	 * @var array<int, array{key: string, api_key: string, api_secret: string, mac_address: string}>
+	 */
+	protected array $connections = array();
+
+	/**
+	 * Create a new instance of the connections.
+	 *
+	 * @param array<int, Connection> $connections
+	 */
+	public function __construct( array $connections = array() ) {
+		$this->connections = array_filter( $connections, fn( $connection ) => $connection instanceof Connection );
+	}
+
+	/**
+	 * Creates an instance of the Connections from arrays
+	 *
+	 * @param array<int, array{key: string, api_key: string, api_secret: string, mac_address: string, ?de}> $connections
+	 *
+	 * @return self
+	 */
+	public static function from_array( array $connections ): self {
+		// Map the connections to Connection objects.
+		$connections = array_map(
+			function ( $data ) {
+				// If we dont have an array, return null.
+				if ( ! is_array( $data ) ) {
+					return null;
+				}
+
+				// If dont have the required keys, return null.
+				$required = array( 'key', 'api_key', 'api_secret', 'mac_address' );
+				if ( count( array_intersect( $required, array_keys( $data ) ) ) !== count( $required ) ) {
+					return null;
+				}
+
+				return new Connection(
+					esc_attr( $data['key'] ),
+					esc_attr( $data['api_key'] ),
+					esc_attr( $data['api_secret'] ),
+					esc_attr( $data['mac_address'] ),
+					isset( $data['description'] ) ? esc_attr( $data['description'] ) : '',
+					isset( $data['name'] ) ? esc_attr( $data['name'] ) : ''
+				);
+			},
+			$connections
+		);
+
+		return new self( $connections );
+	}
+
+	/**
+	 * Adds a connection.
+	 *
+	 * @param string $key         The key for the connection.
+	 * @param string $api_key     The API key.
+	 * @param string $api_secret  The API secret.
+	 * @param string $mac_address The MAC address.
+	 * @param string $description The description.
+	 * @param string $name        The name.
+	 *
+	 * @return void
+	 */
+	public function add(
+		string $key,
+		string $api_key,
+		string $api_secret,
+		string $mac_address,
+		string $description = '',
+		string $name = ''
+	): void {
+		$this->connections[] = new Connection( $key, $api_key, $api_secret, $mac_address, $description, $name );
+	}
+
+	/**
+	 * Gets a connections index based on the key.
+	 *
+	 * @param string $key The key for the connection.
+	 *
+	 * @return integer|null
+	 */
+	public function index( string $key ): ?int {
+		foreach ( $this->connections as $index => $connection ) {
+			if ( $connection->key() === $key ) {
+				return $index;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Checks if we have a connection.
+	 *
+	 * @param string $key The key for the connection.
+	 *
+	 * @return boolean
+	 */
+	public function has( string $key ): bool {
+		$connection = $this->index( $key );
+		return $connection !== null;
+	}
+
+	/**
+	 * Gets a connections details.
+	 *
+	 * @param string $key The key for the connection.
+	 *
+	 * @return Connection|null
+	 */
+	public function get( string $key ): ?Connection {
+		$index = $this->index( $key );
+		if ( $index === null ) {
+			return null;
+		}
+		return $this->connections[ $index ];
+	}
+
+	/**
+	 * Gets all connections.
+	 *
+	 * @return array<int, array{key: string, api_key: string, api_secret: string, mac_address: string}>
+	 */
+	public function all(): array {
+		return $this->connections;
+	}
+
+	/**
+	 * Removes a connection.
+	 *
+	 * @param string $key The key for the connection.
+	 *
+	 * @return void
+	 */
+	public function remove( string $key ): void {
+		$index = $this->index( $key );
+		if ( $index !== null ) {
+			unset( $this->connections[ $index ] );
+		}
+	}
+
+	/**
+	 * Returns the settings as an array.
+	 *
+	 * @return array<int, array{key: string, api_key: string, api_secret: string, mac_address: string, description: string, name: string}>
+	 */
+	public function jsonSerialize(): array {
+		return $this->connections;
+	}
+}

--- a/src/Settings/Exception/Validation_Failed.php
+++ b/src/Settings/Exception/Validation_Failed.php
@@ -1,0 +1,29 @@
+<?php 
+
+declare(strict_types=1);
+
+/**
+ * Exception thrown when validation of settings fails.
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ *
+ * @since 0.1.0
+ */
+
+namespace PinkCrab\Ecowitt_Weather_Block\Settings\Exception;
+
+/**
+ * Validation failed exception.
+ */
+class Validation_Failed extends \RuntimeException {
+    protected array $errors;
+
+    public function __construct( array $errors ) {
+        parent::__construct('Validation failed');
+        $this->errors = $errors;
+    }
+
+    public function get_errors(): array {
+        return $this->errors;
+    }
+}

--- a/src/Settings/Exception/Validation_Failed.php
+++ b/src/Settings/Exception/Validation_Failed.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 
 declare(strict_types=1);
 
@@ -16,14 +16,30 @@ namespace PinkCrab\Ecowitt_Weather_Block\Settings\Exception;
  * Validation failed exception.
  */
 class Validation_Failed extends \RuntimeException {
-    protected array $errors;
 
-    public function __construct( array $errors ) {
-        parent::__construct('Validation failed');
-        $this->errors = $errors;
-    }
+	/**
+	 * The validation errors.
+	 *
+	 * @var string[]
+	 */
+	protected array $errors;
 
-    public function get_errors(): array {
-        return $this->errors;
-    }
+	/**
+	 * Constructor.
+	 *
+	 * @param mixed[] $errors
+	 */
+	public function __construct( array $errors ) {
+		parent::__construct( 'Validation failed' );
+		$this->errors = \array_filter( $errors, fn( $error ) => is_string( $error ) );
+	}
+
+	/**
+	 * Gets the validation errors.
+	 *
+	 * @return string[]
+	 */
+	public function get_errors(): array {
+		return $this->errors;
+	}
 }

--- a/src/Settings/Page/Page_Handler.php
+++ b/src/Settings/Page/Page_Handler.php
@@ -1,0 +1,185 @@
+<?php
+
+/**
+ * The Page_Handler class.
+ *
+ * @since 0.1.0
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Settings\Page;
+
+use PinkCrab\Perique_Admin_Menu\Page\Page;
+use Psr\Http\Message\ServerRequestInterface;
+use PinkCrab\Ecowitt_Weather_Block\Settings\Settings;
+use PinkCrab\Ecowitt_Weather_Block\Admin\Notifications;
+use PinkCrab\Ecowitt_Weather_Block\Settings\Settings_Repository;
+use PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections;
+use PinkCrab\Ecowitt_Weather_Block\Settings\Exception\Validation_Failed;
+
+class Page_Handler {
+	public const FORM_NONCE_KEY = 'ecowitt_settings_nonce';
+	public const SUBMISSION_KEY = 'ecowitt_settings_submit';
+
+	/**
+	 * Server Request
+	 *
+	 * @var ServerRequestInterface
+	 */
+	private ServerRequestInterface $request;
+
+	/**
+	 * The Settings Repository.
+	 *
+	 * @var Settings_Repository
+	 */
+	private Settings_Repository $settings;
+
+	/**
+	 * The form notifications.
+	 *
+	 * @var Notifications
+	 */
+	private Notifications $notifications;
+
+    /**
+     * Backup of settings before changes.
+     * 
+     * @var Settings|null
+     */
+	private ?Settings $backup_settings = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ServerRequestInterface $request
+	 * @param Settings_Repository    $settings
+	 * @param Notifications          $notifications
+	 */
+	public function __construct( ServerRequestInterface $request, Settings_Repository $settings, Notifications $notifications ) {
+		$this->request       = $request;
+		$this->settings      = $settings;
+		$this->notifications = $notifications;
+	}
+
+    /**
+     * Get the notifications instance.
+     * 
+     * @return Notifications
+     */
+    public function get_notifications(): Notifications {
+        return $this->notifications;
+    }
+
+	/**
+	 * Handle the save action.
+	 *
+	 * @param Page $page
+	 * @return void
+	 */
+	public function handle_form_submission( Page $page ): void {
+		// Check that form has been submitted (use ServerRequestInterface to get POST data
+		$post_data = $this->request->getParsedBody();
+		// \dd('post data', $post_data, $this, $_POST);
+        if ( ! isset( $post_data[ self::SUBMISSION_KEY ] ) ) {
+			throw new Validation_Failed( array( 'No submission key found.' ) );
+		}
+		// Verify nonce.
+		if ( ! isset( $post_data[ self::FORM_NONCE_KEY ] ) || ! wp_verify_nonce( $post_data[ self::FORM_NONCE_KEY ], self::FORM_NONCE_KEY ) ) {
+			throw new Validation_Failed( array( 'Invalid nonce.' ) );
+		}
+
+        // Backup current settings in case of failure.
+        $this->backup_settings = $this->settings->load();
+
+		// Process connections.
+		$connections = $this->get_connections($post_data);
+		$connections = Connections::from_array( $connections );
+		$settings    = new Settings( $connections );
+		
+        // If the settings are the same, no need to save.
+        if ( md5( json_encode( $settings ) ) === md5( json_encode( $this->backup_settings ) ) ) {
+            $this->notifications->add_info( 'No changes detected, settings not updated.' );
+            return;
+        }
+        
+        
+        $updated_settings = $this->settings->save( $settings );
+		if ( ! $updated_settings ) {
+			$this->notifications->add_error( 'Failed to save settings, reverting' );
+			if ( $this->backup_settings ) {
+				$this->settings->save( $this->backup_settings );
+			}
+			return;
+		}
+
+        // If 
+		$this->notifications->add_success( 'Updated Connections' );
+
+		// $updated_connections = $this->settings->upsert_connections( $connections );
+		// if( $updated_connections ) {
+		//     $this->notifications->add_success( 'Connections updated successfully.' );
+		// }
+	}
+
+	/**
+	 * Get the connections from the request.
+	 *
+	 * @return array<string, array<string, string>>
+	 */
+	public function get_connections( array $post_data ): array {
+		$keys          = $post_data['connection_key'] ?? array();
+		$names         = $post_data['connection_name'] ?? array();
+		$descriptions  = $post_data['connection_description'] ?? array();
+		$api_keys      = $post_data['connection_api_key'] ?? array();
+		$api_secrets   = $post_data['connection_api_secret'] ?? array();
+		$mac_addresses = $post_data['connection_mac_address'] ?? array();
+
+		if ( 0 === count( $keys ) ) {
+			return array();
+		}
+
+		// Itterate over the keys and build the connections array.
+		$connections = array();
+		foreach ( $keys as $id => $key ) {
+            // If id starts with __new_, generate a unique key.
+            if ( str_starts_with( (string) $id, '__new_' ) ) {
+                $key = $this->get_unique_key( $names[ $id ] ?? 'connection', $connections );
+            }
+            
+            // dd($key);
+			$connections[ $key ] = array(
+				'key'         => \esc_attr( $key ),
+				'name'        => \esc_attr( $names[ $id ] ?? '' ),
+				'description' => \esc_attr( $descriptions[ $id ] ?? '' ),
+				'api_key'     => \esc_attr( $api_keys[ $id ] ?? '' ),
+				'api_secret'  => \esc_attr( $api_secrets[ $id ] ?? '' ),
+				'mac_address' => \esc_attr( $mac_addresses[ $id ] ?? '' ),
+			);
+		}
+
+		return $connections;
+	}
+
+    /**
+     * Get a unique key for a new connection.
+     *
+     * @param string $name The name of the connection.
+     * @param array<string, array<string, string>> $connections
+     * 
+     * @return string
+     */
+    private function get_unique_key( string $name, array $connections ): string {
+        $base_key = sanitize_title( $name );
+        $key = $base_key;
+        $i = 1;
+        while ( isset( $connections[ $key ] ) ) {
+            $key = $base_key . '_' . $i;
+            $i++;
+        }
+        return $key;
+    }
+}

--- a/src/Settings/Page/Page_Handler.php
+++ b/src/Settings/Page/Page_Handler.php
@@ -45,11 +45,11 @@ class Page_Handler {
 	 */
 	private Notifications $notifications;
 
-    /**
-     * Backup of settings before changes.
-     * 
-     * @var Settings|null
-     */
+	/**
+	 * Backup of settings before changes.
+	 *
+	 * @var Settings|null
+	 */
 	private ?Settings $backup_settings = null;
 
 	/**
@@ -65,14 +65,14 @@ class Page_Handler {
 		$this->notifications = $notifications;
 	}
 
-    /**
-     * Get the notifications instance.
-     * 
-     * @return Notifications
-     */
-    public function get_notifications(): Notifications {
-        return $this->notifications;
-    }
+	/**
+	 * Get the notifications instance.
+	 *
+	 * @return Notifications
+	 */
+	public function get_notifications(): Notifications {
+		return $this->notifications;
+	}
 
 	/**
 	 * Handle the save action.
@@ -80,11 +80,11 @@ class Page_Handler {
 	 * @param Page $page
 	 * @return void
 	 */
-	public function handle_form_submission( Page $page ): void {
+	public function handle_form_submission( Page $page ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found, required as extending.
 		// Check that form has been submitted (use ServerRequestInterface to get POST data
-		$post_data = $this->request->getParsedBody();
-		// \dd('post data', $post_data, $this, $_POST);
-        if ( ! isset( $post_data[ self::SUBMISSION_KEY ] ) ) {
+		$post_data = (array) $this->request->getParsedBody();
+
+		if ( ! isset( $post_data[ self::SUBMISSION_KEY ] ) ) {
 			throw new Validation_Failed( array( 'No submission key found.' ) );
 		}
 		// Verify nonce.
@@ -92,22 +92,21 @@ class Page_Handler {
 			throw new Validation_Failed( array( 'Invalid nonce.' ) );
 		}
 
-        // Backup current settings in case of failure.
-        $this->backup_settings = $this->settings->load();
+		// Backup current settings in case of failure.
+		$this->backup_settings = $this->settings->load();
 
 		// Process connections.
-		$connections = $this->get_connections($post_data);
+		$connections = $this->get_connections( $post_data );
 		$connections = Connections::from_array( $connections );
 		$settings    = new Settings( $connections );
-		
-        // If the settings are the same, no need to save.
-        if ( md5( json_encode( $settings ) ) === md5( json_encode( $this->backup_settings ) ) ) {
-            $this->notifications->add_info( 'No changes detected, settings not updated.' );
-            return;
-        }
-        
-        
-        $updated_settings = $this->settings->save( $settings );
+
+		// If the settings are the same, no need to save.
+		if ( md5( \wp_json_encode( $settings ) ?: 'new_settings' ) === md5( \wp_json_encode( $this->backup_settings ) ?: 'cached_settings' ) ) {
+			$this->notifications->add_info( 'No changes detected, settings not updated.' );
+			return;
+		}
+
+		$updated_settings = $this->settings->save( $settings );
 		if ( ! $updated_settings ) {
 			$this->notifications->add_error( 'Failed to save settings, reverting' );
 			if ( $this->backup_settings ) {
@@ -115,20 +114,24 @@ class Page_Handler {
 			}
 			return;
 		}
-
-        // If 
 		$this->notifications->add_success( 'Updated Connections' );
-
-		// $updated_connections = $this->settings->upsert_connections( $connections );
-		// if( $updated_connections ) {
-		//     $this->notifications->add_success( 'Connections updated successfully.' );
-		// }
 	}
 
 	/**
 	 * Get the connections from the request.
 	 *
-	 * @return array<string, array<string, string>>
+	 * @template RequestData of array{
+	 *  connection_key?: array<string, string>,
+	 *  connection_name?: array<string, string>,
+	 *  connection_description?: array<string, string>,
+	 *  connection_api_key?: array<string, string>,
+	 *  connection_api_secret?: array<string, string>,
+	 *  connection_mac_address?: array<string, string>,
+	 * }
+	 *
+	 * @param RequestData $post_data The post data from the request.
+	 *
+	 * @return array<string, array{key: string, api_key: string, api_secret: string, mac_address: string, description: string, name: string}>
 	 */
 	public function get_connections( array $post_data ): array {
 		$keys          = $post_data['connection_key'] ?? array();
@@ -142,15 +145,14 @@ class Page_Handler {
 			return array();
 		}
 
-		// Itterate over the keys and build the connections array.
+		// Iterate over the keys and build the connections array.
 		$connections = array();
 		foreach ( $keys as $id => $key ) {
-            // If id starts with __new_, generate a unique key.
-            if ( str_starts_with( (string) $id, '__new_' ) ) {
-                $key = $this->get_unique_key( $names[ $id ] ?? 'connection', $connections );
-            }
-            
-            // dd($key);
+			// If id starts with __new_, generate a unique key.
+			if ( str_starts_with( (string) $id, '__new_' ) ) {
+				$key = $this->get_unique_key( $names[ $id ] ?? 'connection', $connections );
+			}
+
 			$connections[ $key ] = array(
 				'key'         => \esc_attr( $key ),
 				'name'        => \esc_attr( $names[ $id ] ?? '' ),
@@ -164,22 +166,22 @@ class Page_Handler {
 		return $connections;
 	}
 
-    /**
-     * Get a unique key for a new connection.
-     *
-     * @param string $name The name of the connection.
-     * @param array<string, array<string, string>> $connections
-     * 
-     * @return string
-     */
-    private function get_unique_key( string $name, array $connections ): string {
-        $base_key = sanitize_title( $name );
-        $key = $base_key;
-        $i = 1;
-        while ( isset( $connections[ $key ] ) ) {
-            $key = $base_key . '_' . $i;
-            $i++;
-        }
-        return $key;
-    }
+	/**
+	 * Get a unique key for a new connection.
+	 *
+	 * @param string                               $name        The name of the connection.
+	 * @param array<string, array<string, string>> $connections
+	 *
+	 * @return string
+	 */
+	private function get_unique_key( string $name, array $connections ): string {
+		$base_key = sanitize_title( $name );
+		$key      = $base_key;
+		$i        = 1;
+		while ( isset( $connections[ $key ] ) ) {
+			$key = $base_key . '_' . $i;
+			++$i;
+		}
+		return $key;
+	}
 }

--- a/src/Settings/Page/Settings_Page.php
+++ b/src/Settings/Page/Settings_Page.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * The Settings_Page class.
+ *
+ * @since 0.1.0
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Settings\Page;
+
+use PinkCrab\Enqueue\Enqueue;
+use PinkCrab\Perique_Admin_Menu\Page\Page;
+use PinkCrab\Perique\Application\App_Config;
+use PinkCrab\Perique_Admin_Menu\Page\Menu_Page;
+use PinkCrab\Ecowitt_Weather_Block\Settings\Settings;
+use PinkCrab\Ecowitt_Weather_Block\View\Component\Settings\Connections\Settings_Connections;
+
+
+/**
+ * The Settings_Page class.
+ */
+class Settings_Page extends Menu_Page {
+
+	/**
+	 * Holds the App Config.
+	 *
+	 * @var App_Config
+	 */
+	protected App_Config $app_config;
+
+	/**
+	 * Access to the Settings
+	 *
+	 * @var Settings
+	 */
+	protected Settings $settings;
+
+	/**
+	 * Page Handler for callbacks.
+	 *
+	 * @var Page_Handler
+	 */
+	protected Page_Handler $page_handler;
+
+	/**
+	 * Creates an instance of the Settings_Page.
+	 *
+	 * @param App_Config $app_config
+	 * @param Settings   $settings
+	 * @param Page_Handler $page_handler
+	 */
+	public function __construct( App_Config $app_config, Settings $settings, Page_Handler $page_handler ) {
+		$this->app_config = $app_config;
+		$this->settings   = $settings;
+		$this->page_handler = $page_handler;
+
+		// Set the page details.
+		$this->page_slug  = 'ecowitt-weather-block-settings';
+		$this->menu_title = 'Ecowitt Weather Block';
+		$this->page_title = 'Ecowitt Weather Block Settings';
+		$this->position   = 10;
+
+		$this->view_template = 'admin.settings.page';
+		$this->view_data     = array(
+			'app_config'  => $this->app_config,
+			'settings'    => $this->settings,
+			'page'        => $this,
+			'connections' => new Settings_Connections( $this->settings->connections()->all() ),
+			'form_nonce_key'  => $this->page_handler::FORM_NONCE_KEY,
+			'submission_key' => $this->page_handler::SUBMISSION_KEY,
+			'notifications' => $this->page_handler->get_notifications(),
+		);
+	}
+
+	/**
+	 * Callback for enqueuing scripts and styles at a page level.
+	 *
+	 * @param Page $page
+	 * @return void
+	 */
+	public function enqueue( Page $page ): void {
+		Enqueue::script( 'ecowittSettings' )
+			->src( $this->app_config->url( 'assets' ) . 'js/settings.js' )
+			->ver( $this->app_config->version() )
+			->localize( array(
+				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+				'nonce'   => wp_create_nonce( 'ecowitt_settings_nonce' ),
+				'connectionTemplate' => $this->view->render(
+					'components.admin.settings.connection',
+					array(
+						'key'               => '{key}',
+						'connection_id'     => '{key}',  // Add this for template compatibility
+						'api_key'           => '{api_key}',
+						'api_secret'        => '{api_secret}',
+						'mac_address'       => '{mac_address}',
+						'description'       => '{description}',
+						'name'              => '{name}',
+						'api_key_masked'    => '{api_key_masked}',
+						'api_secret_masked' => '{api_secret_masked}',
+					), false
+				)
+			) )
+			->register();
+	}
+
+	/**
+	 * Callback for the pre-load of the page
+	 *
+	 * @param Page $page
+	 * @return void
+	 */
+	public function load( Page $page ): void {
+		// Check if the form was submitted.
+		if ( isset($_POST[$this->page_handler::SUBMISSION_KEY]) ) {
+			$this->page_handler->handle_form_submission( $this );
+		}
+	}
+}

--- a/src/Settings/Page/Settings_Page.php
+++ b/src/Settings/Page/Settings_Page.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace PinkCrab\Ecowitt_Weather_Block\Settings\Page;
 
+use PinkCrab\Ecowitt_Weather_Block\Admin\Asset_Loader;
 use PinkCrab\Enqueue\Enqueue;
 use PinkCrab\Perique_Admin_Menu\Page\Page;
 use PinkCrab\Perique\Application\App_Config;
@@ -54,8 +55,8 @@ class Settings_Page extends Menu_Page {
 	 * @param Page_Handler $page_handler
 	 */
 	public function __construct( App_Config $app_config, Settings $settings, Page_Handler $page_handler ) {
-		$this->app_config = $app_config;
-		$this->settings   = $settings;
+		$this->app_config   = $app_config;
+		$this->settings     = $settings;
 		$this->page_handler = $page_handler;
 
 		// Set the page details.
@@ -66,13 +67,13 @@ class Settings_Page extends Menu_Page {
 
 		$this->view_template = 'admin.settings.page';
 		$this->view_data     = array(
-			'app_config'  => $this->app_config,
-			'settings'    => $this->settings,
-			'page'        => $this,
-			'connections' => new Settings_Connections( $this->settings->connections()->all() ),
-			'form_nonce_key'  => $this->page_handler::FORM_NONCE_KEY,
+			'app_config'     => $this->app_config,
+			'settings'       => $this->settings,
+			'page'           => $this,
+			'connections'    => new Settings_Connections( $this->settings->connections()->all() ),
+			'form_nonce_key' => $this->page_handler::FORM_NONCE_KEY,
 			'submission_key' => $this->page_handler::SUBMISSION_KEY,
-			'notifications' => $this->page_handler->get_notifications(),
+			'notifications'  => $this->page_handler->get_notifications(),
 		);
 	}
 
@@ -83,27 +84,34 @@ class Settings_Page extends Menu_Page {
 	 * @return void
 	 */
 	public function enqueue( Page $page ): void {
+
+		// Assert that the view is set.
+		assert( $this->view instanceof \PinkCrab\Perique\Services\View\View );
+
 		Enqueue::script( 'ecowittSettings' )
-			->src( $this->app_config->url( 'assets' ) . 'js/settings.js' )
+			->src( Asset_Loader::assets_url() . 'js/settings.js' )
 			->ver( $this->app_config->version() )
-			->localize( array(
-				'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-				'nonce'   => wp_create_nonce( 'ecowitt_settings_nonce' ),
-				'connectionTemplate' => $this->view->render(
-					'components.admin.settings.connection',
-					array(
-						'key'               => '{key}',
-						'connection_id'     => '{key}',  // Add this for template compatibility
-						'api_key'           => '{api_key}',
-						'api_secret'        => '{api_secret}',
-						'mac_address'       => '{mac_address}',
-						'description'       => '{description}',
-						'name'              => '{name}',
-						'api_key_masked'    => '{api_key_masked}',
-						'api_secret_masked' => '{api_secret_masked}',
-					), false
+			->localize(
+				array(
+					'ajaxUrl'            => admin_url( 'admin-ajax.php' ),
+					'nonce'              => wp_create_nonce( 'ecowitt_settings_nonce' ),
+					'connectionTemplate' => $this->view->render(
+						'components.admin.settings.connection',
+						array(
+							'key'               => '{key}',
+							'connection_id'     => '{key}',  // Add this for template compatibility
+							'api_key'           => '{api_key}',
+							'api_secret'        => '{api_secret}',
+							'mac_address'       => '{mac_address}',
+							'description'       => '{description}',
+							'name'              => '{name}',
+							'api_key_masked'    => '{api_key_masked}',
+							'api_secret_masked' => '{api_secret_masked}',
+						),
+						false
+					),
 				)
-			) )
+			)
 			->register();
 	}
 
@@ -115,7 +123,7 @@ class Settings_Page extends Menu_Page {
 	 */
 	public function load( Page $page ): void {
 		// Check if the form was submitted.
-		if ( isset($_POST[$this->page_handler::SUBMISSION_KEY]) ) {
+		if ( isset( $_POST[ $this->page_handler::SUBMISSION_KEY ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing, Only checking if set.
 			$this->page_handler->handle_form_submission( $this );
 		}
 	}

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -44,7 +44,10 @@ class Settings implements JsonSerializable {
 	 */
 	public static function from_json( string $json ): self {
 		$data        = json_decode( $json, true );
-		$connections = Connections::from_array( $data['connections'] ?? array() );
+		$connections = is_array( $data ) && isset( $data['connections'] ) && is_array( $data['connections'] )
+			? $data['connections']
+			: array();
+		$connections = Connections::from_array( $connections );
 
 		return new self( $connections );
 	}

--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * Holds the settings for the plugin.
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ *
+ * @since 0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Settings;
+
+use JsonSerializable;
+use PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections;
+
+/**
+ * Holds the settings for the plugin.
+ */
+class Settings implements JsonSerializable {
+
+	/**
+	 * Holds the connection data.
+	 *
+	 * @var Connections
+	 */
+	protected Connections $connections;
+
+	/**
+	 * Creates an instance of the Settings.
+	 *
+	 * @param Connections $connections The connections.
+	 */
+	public function __construct( Connections $connections ) {
+		$this->connections = $connections;
+	}
+
+
+	/**
+	 * Creates an instance of the Settings from a JSON string.
+	 *
+	 * @param string $json
+	 */
+	public static function from_json( string $json ): self {
+		$data        = json_decode( $json, true );
+		$connections = Connections::from_array( $data['connections'] ?? array() );
+
+		return new self( $connections );
+	}
+
+	/**
+	 * Access to the connections.
+	 *
+	 * @return Connections
+	 */
+	public function connections(): Connections {
+		return $this->connections;
+	}
+
+
+	/**
+	 * Returns the settings as an array.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function jsonSerialize(): array {
+		return array(
+			'connections' => $this->connections,
+		);
+	}
+}

--- a/src/Settings/Settings_Repository.php
+++ b/src/Settings/Settings_Repository.php
@@ -33,7 +33,7 @@ class Settings_Repository {
 	 * @return Settings|null
 	 */
 	public function save( Settings $settings ): ?Settings {
-		update_option( $this->settings_key, json_encode( $settings ) );
+		update_option( $this->settings_key, wp_json_encode( $settings ) );
 		return $this->load();
 	}
 
@@ -44,6 +44,7 @@ class Settings_Repository {
 	 */
 	public function load(): ?Settings {
 		$settings = get_option( $this->settings_key, null );
+		$settings = is_string( $settings ) ? $settings : null;
 		return $settings ? Settings::from_json( $settings ) : null;
 	}
 }

--- a/src/Settings/Settings_Repository.php
+++ b/src/Settings/Settings_Repository.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * Handles the saving and loading of the settings.
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ *
+ * @since 0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Settings;
+
+/**
+ * Handles the saving and loading of the settings.
+ */
+class Settings_Repository {
+
+	/**
+	 * The key used to store the settings.
+	 *
+	 * @var string
+	 */
+	protected string $settings_key = 'ecowitt_weather_block_settings';
+
+
+	/**
+	 * Saves the settings.
+	 *
+	 * @param Settings $settings
+	 *
+	 * @return Settings|null
+	 */
+	public function save( Settings $settings ): ?Settings {
+		update_option( $this->settings_key, json_encode( $settings ) );
+		return $this->load();
+	}
+
+	/**
+	 * Loads the settings.
+	 *
+	 * @return Settings|null
+	 */
+	public function load(): ?Settings {
+		$settings = get_option( $this->settings_key, null );
+		return $settings ? Settings::from_json( $settings ) : null;
+	}
+}

--- a/src/View/Component/Settings/Connections/Settings_Connection.php
+++ b/src/View/Component/Settings/Connections/Settings_Connection.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * The settings page, connection component.
+ *
+ * @since 0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\View\Component\Settings\Connections;
+
+use PinkCrab\Perique\Services\View\Component\Component;
+use PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection;
+
+/**
+ * The settings page, connection component.
+ *
+ * @view admin.settings.connection
+ */
+class Settings_Connection extends Component {
+
+	public string $key         = '';
+	public string $api_key     = '';
+	public string $api_secret  = '';
+	public string $mac_address = '';
+	public string $description = '';
+	public string $name        = '';
+
+	/**
+	 * Creates an instance of the Setting_Connection_Component.
+	 *
+	 * @param Connection $connection
+	 */
+	public function __construct( ?Connection $connection = null ) {
+		if ( is_null( $connection ) ) {
+			return;
+		}
+
+		$this->key         = $connection->key();
+		$this->api_key     = $connection->api_key();
+		$this->api_secret  = $connection->api_secret();
+		$this->mac_address = $connection->mac_address();
+		$this->description = $connection->description();
+		$this->name        = $connection->name();
+	}
+}

--- a/src/View/Component/Settings/Connections/Settings_Connections.php
+++ b/src/View/Component/Settings/Connections/Settings_Connections.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * The settings page, connections component.
+ *
+ * @since 0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\View\Component\Settings\Connections;
+
+use PinkCrab\Perique\Services\View\Component\Component;
+use PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection;
+
+/**
+ * The settings page, connections component.
+ *
+ * @view admin.settings.connections
+ */
+class Settings_Connections extends Component {
+
+	/**
+	 * The connections.
+	 *
+	 * @var array<int, Connection>
+	 */
+	protected array $connections = array();
+
+	/**
+	 * Creates an instance of the Setting_Connections_Component.
+	 *
+	 * @param array<int, Connection> $connections
+	 */
+	public function __construct( array $connections = array() ) {
+		$connections       = array_filter( $connections, fn( $connection ) => $connection instanceof Connection );
+		$this->connections = array_map( fn( $connection ) => new Settings_Connection( $connection ), $connections );
+	}
+}

--- a/src/View/Component/Settings/Connections/Settings_Connections.php
+++ b/src/View/Component/Settings/Connections/Settings_Connections.php
@@ -23,14 +23,14 @@ class Settings_Connections extends Component {
 	/**
 	 * The connections.
 	 *
-	 * @var array<int, Connection>
+	 * @var array<int, Settings_Connection>
 	 */
 	protected array $connections = array();
 
 	/**
 	 * Creates an instance of the Setting_Connections_Component.
 	 *
-	 * @param array<int, Connection> $connections
+	 * @param array<int, mixed> $connections
 	 */
 	public function __construct( array $connections = array() ) {
 		$connections       = array_filter( $connections, fn( $connection ) => $connection instanceof Connection );

--- a/tests/Unit/Admin/Test_Notifications.php
+++ b/tests/Unit/Admin/Test_Notifications.php
@@ -1,0 +1,151 @@
+<?php
+
+/**
+ * Tests for the Admin Notifications class.
+ *
+ * @since 0.1.0
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Tests\Unit\Admin;
+
+use Gin0115\WPUnit_Helpers\Output;
+use PinkCrab\Ecowitt_Weather_Block\Admin\Notifications;
+
+/**
+ * Tests for the Admin Notifications class.
+ * 
+ * @group unit
+ * @group admin
+ */
+class Test_Notifications extends \WP_UnitTestCase {
+
+    // public function set_up(): void {
+	// 	parent::set_up();
+	// }
+
+    /**
+     * @testdox It should be possible to add a success notification.
+     * @cover \PinkCrab\Ecowitt_Weather_Block\Admin\Notifications::add_success
+     */
+    public function test_add_success_notification(): void {
+        $notifications = new Notifications();
+        $notifications->add_success( 'Test success message.' );
+        $this->assertCount( 1, $notifications->get_notifications() );
+        $this->assertSame( 'Test success message.', $notifications->get_notifications()[0]['message'] );
+        $this->assertSame( 'success', $notifications->get_notifications()[0]['type'] );
+        
+        // Render and check output.
+        $rendered = Output::buffer( fn() => $notifications->render_notifications() );
+        $this->assertNotNull( $rendered);
+        // Check the rendered output contains the message. and notice-success class.
+        $this->assertStringContainsString( 'Test success message.', $rendered );
+        $this->assertStringContainsString( 'notice-success', $rendered );
+    }
+
+    /**
+     * @testdox It should be possible to add an error notification.
+     * @cover \PinkCrab\Ecowitt_Weather_Block\Admin\Notifications::add_error
+     */
+    public function test_add_error_notification(): void {
+        $notifications = new Notifications();
+        $notifications->add_error( 'Test error message.' );
+        $this->assertCount( 1, $notifications->get_notifications() );
+        $this->assertSame( 'Test error message.', $notifications->get_notifications()[0]['message'] );
+        $this->assertSame( 'error', $notifications->get_notifications()[0]['type'] );   
+        // Render and check output.
+        $rendered = Output::buffer( fn() => $notifications->render_notifications() );
+        $this->assertNotNull( $rendered);
+        // Check the rendered output contains the message. and notice-error class.
+        $this->assertStringContainsString( 'Test error message.', $rendered );
+        $this->assertStringContainsString( 'notice-error', $rendered );
+    }
+
+    /**
+     * @testdox It should be possible to add an info notification.
+     * @cover \PinkCrab\Ecowitt_Weather_Block\Admin\Notifications::add_info
+     */
+    public function test_add_info_notification(): void {
+        $notifications = new Notifications();
+        $notifications->add_info( 'Test info message.' );
+        $this->assertCount( 1, $notifications->get_notifications() );
+        $this->assertSame( 'Test info message.', $notifications->get_notifications()[0]['message'] );
+        $this->assertSame( 'info', $notifications->get_notifications()[0]['type'] );
+
+        // Render and check output.
+        $rendered = Output::buffer( fn() => $notifications->render_notifications() );
+        $this->assertNotNull( $rendered);
+        // Check the rendered output contains the message. and notice-info class.
+        $this->assertStringContainsString( 'Test info message.', $rendered );
+        $this->assertStringContainsString( 'notice-info', $rendered );
+    }
+
+    /**
+     * @testdox When an empty notification is added, it should still be stored but not rendered.
+     * @cover \PinkCrab\Ecowitt_Weather_Block\Admin\Notifications::add_notification
+     */
+    public function test_add_empty_success_notification(): void {
+        $notifications = new Notifications();
+        $notifications->add_notification( 'foo', '' );
+        
+        
+        $this->assertCount( 1, $notifications->get_notifications() );
+        $this->assertSame( '', $notifications->get_notifications()[0]['message'] );
+        $this->assertSame( 'foo', $notifications->get_notifications()[0]['type'] );
+
+        // Render and check output.
+        $rendered = Output::buffer( fn() => $notifications->render_notifications() );
+        $this->assertEquals( '', $rendered );
+    }
+
+    /**
+     * @testdox It should be possible to check if we have any notifications.
+     * @cover \PinkCrab\Ecowitt_Weather_Block\Admin\Notifications::has_notifications
+     */
+    public function test_has_notifications(): void {
+        $notifications = new Notifications();
+        $this->assertFalse( $notifications->has_notifications() );
+        $notifications->add_success( 'Test success message.' );
+        $this->assertTrue( $notifications->has_notifications() );
+    }
+
+    /**
+     * @testdox It should be possible to render multiple notifications.
+     * @cover \PinkCrab\Ecowitt_Weather_Block\Admin\Notifications::render_notifications
+     */
+    public function test_render_multiple_notifications(): void {
+        $notifications = new Notifications();
+        $notifications->add_success( 'Test success message.' );
+        $notifications->add_error( 'Test error message.' );
+        $notifications->add_info( 'Test info message.' );
+
+        // Render and check output.
+        $rendered = Output::buffer( fn() => $notifications->render_notifications() );
+        $this->assertNotNull( $rendered );
+        // Check the rendered output contains all messages and respective classes.
+        $this->assertStringContainsString( 'Test success message.', $rendered );
+        $this->assertStringContainsString( 'notice-success', $rendered );
+        $this->assertStringContainsString( 'Test error message.', $rendered );
+        $this->assertStringContainsString( 'notice-error', $rendered );
+        $this->assertStringContainsString( 'Test info message.', $rendered );
+        $this->assertStringContainsString( 'notice-info', $rendered );
+
+    }
+
+    /**
+     * @testdox it should be possible to clear notifications.
+     * @cover \PinkCrab\Ecowitt_Weather_Block\Admin\Notifications::clear_notifications
+     */
+    public function test_clear_notifications(): void {
+        $notifications = new Notifications();
+        $notifications->add_success( 'Test success message.' );
+        $notifications->add_error( 'Test error message.' );
+        $notifications->add_info( 'Test info message.' );
+        $this->assertCount( 3, $notifications->get_notifications() );
+        $notifications->clear_notifications();
+        $this->assertCount( 0, $notifications->get_notifications() );
+    }   
+}

--- a/tests/Unit/Ecowitt/Api/Connection/Test_Connection.php
+++ b/tests/Unit/Ecowitt/Api/Connection/Test_Connection.php
@@ -1,0 +1,305 @@
+<?php
+
+/**
+ * Tests for the Connection class.
+ *
+ * @since 0.1.0
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Tests\Unit\Ecowitt\Api\Connection;
+
+use PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection;
+
+/**
+ * Tests for the Connection class.
+ * 
+ * @group unit
+ * @group ecowitt
+ * @group connection
+ */
+class Test_Connection extends \WP_UnitTestCase {
+
+    /**
+     * Sample connection data for testing.
+     * 
+     * @var array<string, string>
+     */
+    private array $sample_data;
+
+    public function set_up(): void {
+        parent::set_up();
+        
+        $this->sample_data = array(
+            'key'         => 'test_key_123',
+            'api_key'     => 'api_key_456',
+            'api_secret'  => 'api_secret_789',
+            'mac_address' => '00:11:22:33:44:55',
+            'description' => 'Test weather station',
+            'name'        => 'My Weather Station',
+        );
+    }
+
+    /**
+     * @testdox It should be possible to create a Connection instance with all required parameters.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::__construct
+     */
+    public function test_can_create_connection_instance(): void {
+        $connection = new Connection(
+            $this->sample_data['key'],
+            $this->sample_data['api_key'],
+            $this->sample_data['api_secret'],
+            $this->sample_data['mac_address'],
+            $this->sample_data['description'],
+            $this->sample_data['name']
+        );
+
+        $this->assertInstanceOf( Connection::class, $connection );
+    }
+
+    /**
+     * @testdox It should return the correct key value.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::key
+     */
+    public function test_can_get_key(): void {
+        $connection = new Connection(
+            $this->sample_data['key'],
+            $this->sample_data['api_key'],
+            $this->sample_data['api_secret'],
+            $this->sample_data['mac_address'],
+            $this->sample_data['description'],
+            $this->sample_data['name']
+        );
+
+        $this->assertSame( $this->sample_data['key'], $connection->key() );
+    }
+
+    /**
+     * @testdox It should return the correct API key value.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::api_key
+     */
+    public function test_can_get_api_key(): void {
+        $connection = new Connection(
+            $this->sample_data['key'],
+            $this->sample_data['api_key'],
+            $this->sample_data['api_secret'],
+            $this->sample_data['mac_address'],
+            $this->sample_data['description'],
+            $this->sample_data['name']
+        );
+
+        $this->assertSame( $this->sample_data['api_key'], $connection->api_key() );
+    }
+
+    /**
+     * @testdox It should return the correct API secret value.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::api_secret
+     */
+    public function test_can_get_api_secret(): void {
+        $connection = new Connection(
+            $this->sample_data['key'],
+            $this->sample_data['api_key'],
+            $this->sample_data['api_secret'],
+            $this->sample_data['mac_address'],
+            $this->sample_data['description'],
+            $this->sample_data['name']
+        );
+
+        $this->assertSame( $this->sample_data['api_secret'], $connection->api_secret() );
+    }
+
+    /**
+     * @testdox It should return the correct MAC address value.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::mac_address
+     */
+    public function test_can_get_mac_address(): void {
+        $connection = new Connection(
+            $this->sample_data['key'],
+            $this->sample_data['api_key'],
+            $this->sample_data['api_secret'],
+            $this->sample_data['mac_address'],
+            $this->sample_data['description'],
+            $this->sample_data['name']
+        );
+
+        $this->assertSame( $this->sample_data['mac_address'], $connection->mac_address() );
+    }
+
+    /**
+     * @testdox It should return the correct description value.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::description
+     */
+    public function test_can_get_description(): void {
+        $connection = new Connection(
+            $this->sample_data['key'],
+            $this->sample_data['api_key'],
+            $this->sample_data['api_secret'],
+            $this->sample_data['mac_address'],
+            $this->sample_data['description'],
+            $this->sample_data['name']
+        );
+
+        $this->assertSame( $this->sample_data['description'], $connection->description() );
+    }
+
+    /**
+     * @testdox It should return the correct name value.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::name
+     */
+    public function test_can_get_name(): void {
+        $connection = new Connection(
+            $this->sample_data['key'],
+            $this->sample_data['api_key'],
+            $this->sample_data['api_secret'],
+            $this->sample_data['mac_address'],
+            $this->sample_data['description'],
+            $this->sample_data['name']
+        );
+
+        $this->assertSame( $this->sample_data['name'], $connection->name() );
+    }
+
+    /**
+     * @testdox It should escape HTML attributes in constructor parameters.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::__construct
+     */
+    public function test_constructor_escapes_html_attributes(): void {
+        $malicious_data = array(
+            'key'         => '<script>alert("xss")</script>',
+            'api_key'     => '">alert("xss")<',
+            'api_secret'  => '&lt;script&gt;',
+            'mac_address' => '"onclick="alert(1)"',
+            'description' => '<img src=x onerror=alert(1)>',
+            'name'        => '<b>bold</b>',
+        );
+
+        $connection = new Connection(
+            $malicious_data['key'],
+            $malicious_data['api_key'],
+            $malicious_data['api_secret'],
+            $malicious_data['mac_address'],
+            $malicious_data['description'],
+            $malicious_data['name']
+        );
+
+        // Check that all values are properly escaped
+        $this->assertSame( esc_attr( $malicious_data['key'] ), $connection->key() );
+        $this->assertSame( esc_attr( $malicious_data['api_key'] ), $connection->api_key() );
+        $this->assertSame( esc_attr( $malicious_data['api_secret'] ), $connection->api_secret() );
+        $this->assertSame( esc_attr( $malicious_data['mac_address'] ), $connection->mac_address() );
+        $this->assertSame( esc_attr( $malicious_data['description'] ), $connection->description() );
+        $this->assertSame( esc_attr( $malicious_data['name'] ), $connection->name() );
+    }
+
+    /**
+     * @testdox It should implement JsonSerializable and return correct array structure.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::jsonSerialize
+     */
+    public function test_implements_json_serializable(): void {
+        $connection = new Connection(
+            $this->sample_data['key'],
+            $this->sample_data['api_key'],
+            $this->sample_data['api_secret'],
+            $this->sample_data['mac_address'],
+            $this->sample_data['description'],
+            $this->sample_data['name']
+        );
+
+        $this->assertInstanceOf( \JsonSerializable::class, $connection );
+
+        $serialized = $connection->jsonSerialize();
+        $this->assertIsArray( $serialized );
+        
+        // Check all expected keys are present
+        $expected_keys = array( 'key', 'api_key', 'api_secret', 'mac_address', 'description', 'name' );
+        foreach ( $expected_keys as $key ) {
+            $this->assertArrayHasKey( $key, $serialized );
+        }
+
+        // Check values match
+        $this->assertSame( $this->sample_data['key'], $serialized['key'] );
+        $this->assertSame( $this->sample_data['api_key'], $serialized['api_key'] );
+        $this->assertSame( $this->sample_data['api_secret'], $serialized['api_secret'] );
+        $this->assertSame( $this->sample_data['mac_address'], $serialized['mac_address'] );
+        $this->assertSame( $this->sample_data['description'], $serialized['description'] );
+        $this->assertSame( $this->sample_data['name'], $serialized['name'] );
+    }
+
+    /**
+     * @testdox It should be possible to JSON encode the Connection object.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::jsonSerialize
+     */
+    public function test_can_json_encode_connection(): void {
+        $connection = new Connection(
+            $this->sample_data['key'],
+            $this->sample_data['api_key'],
+            $this->sample_data['api_secret'],
+            $this->sample_data['mac_address'],
+            $this->sample_data['description'],
+            $this->sample_data['name']
+        );
+
+        $json = json_encode( $connection );
+        $this->assertIsString( $json );
+        $this->assertNotFalse( $json );
+
+        $decoded = json_decode( $json, true );
+        $this->assertIsArray( $decoded );
+        
+        // Verify the decoded data matches our sample data
+        foreach ( $this->sample_data as $key => $value ) {
+            $this->assertArrayHasKey( $key, $decoded );
+            $this->assertSame( $value, $decoded[$key] );
+        }
+    }
+
+    /**
+     * @testdox It should handle empty string values correctly.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::__construct
+     */
+    public function test_handles_empty_string_values(): void {
+        $connection = new Connection( '', '', '', '', '', '' );
+
+        $this->assertSame( '', $connection->key() );
+        $this->assertSame( '', $connection->api_key() );
+        $this->assertSame( '', $connection->api_secret() );
+        $this->assertSame( '', $connection->mac_address() );
+        $this->assertSame( '', $connection->description() );
+        $this->assertSame( '', $connection->name() );
+    }
+
+    /**
+     * @testdox It should handle special characters and unicode correctly.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection::__construct
+     */
+    public function test_handles_special_characters(): void {
+        $special_data = array(
+            'key'         => 'key_with_üñïçødé',
+            'api_key'     => 'api-key/with+symbols@domain.com',
+            'api_secret'  => 'secret_with_$pecial_ch@rs!',
+            'mac_address' => 'aa:bb:cc:dd:ee:ff',
+            'description' => 'Weather station with émojis 🌡️🌦️',
+            'name'        => 'Statiön Météo',
+        );
+
+        $connection = new Connection(
+            $special_data['key'],
+            $special_data['api_key'],
+            $special_data['api_secret'],
+            $special_data['mac_address'],
+            $special_data['description'],
+            $special_data['name']
+        );
+
+        // All values should be properly escaped but preserve valid characters
+        $this->assertSame( esc_attr( $special_data['key'] ), $connection->key() );
+        $this->assertSame( esc_attr( $special_data['api_key'] ), $connection->api_key() );
+        $this->assertSame( esc_attr( $special_data['api_secret'] ), $connection->api_secret() );
+        $this->assertSame( esc_attr( $special_data['mac_address'] ), $connection->mac_address() );
+        $this->assertSame( esc_attr( $special_data['description'] ), $connection->description() );
+        $this->assertSame( esc_attr( $special_data['name'] ), $connection->name() );
+    }
+}

--- a/tests/Unit/Ecowitt/Api/Connection/Test_Connections.php
+++ b/tests/Unit/Ecowitt/Api/Connection/Test_Connections.php
@@ -1,0 +1,455 @@
+<?php
+
+/**
+ * Tests for the Connections class.
+ *
+ * @since 0.1.0
+ *
+ * @package PinkCrab\Ecowitt_Weather_Block
+ */
+
+declare(strict_types=1);
+
+namespace PinkCrab\Ecowitt_Weather_Block\Tests\Unit\Ecowitt\Api\Connection;
+
+use PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connection;
+use PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections;
+
+/**
+ * Tests for the Connections class.
+ * 
+ * @group unit
+ * @group ecowitt
+ * @group connections
+ */
+class Test_Connections extends \WP_UnitTestCase {
+
+    /**
+     * Sample connection data for testing.
+     * 
+     * @var array<string, array<string, string>>
+     */
+    private array $sample_connections;
+
+    public function set_up(): void {
+        parent::set_up();
+        
+        $this->sample_connections = array(
+            'connection1' => array(
+                'key'         => 'conn_1',
+                'api_key'     => 'api_key_1',
+                'api_secret'  => 'api_secret_1',
+                'mac_address' => '00:11:22:33:44:55',
+                'description' => 'First weather station',
+                'name'        => 'Station One',
+            ),
+            'connection2' => array(
+                'key'         => 'conn_2',
+                'api_key'     => 'api_key_2',
+                'api_secret'  => 'api_secret_2',
+                'mac_address' => 'aa:bb:cc:dd:ee:ff',
+                'description' => 'Second weather station',
+                'name'        => 'Station Two',
+            ),
+        );
+    }
+
+    /**
+     * @testdox It should be possible to create an empty Connections instance.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::__construct
+     */
+    public function test_can_create_empty_connections(): void {
+        $connections = new Connections();
+        $this->assertInstanceOf( Connections::class, $connections );
+        $this->assertEmpty( $connections->all() );
+    }
+
+    /**
+     * @testdox It should be possible to create Connections instance with Connection objects.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::__construct
+     */
+    public function test_can_create_connections_with_objects(): void {
+        $connection1 = new Connection(
+            $this->sample_connections['connection1']['key'],
+            $this->sample_connections['connection1']['api_key'],
+            $this->sample_connections['connection1']['api_secret'],
+            $this->sample_connections['connection1']['mac_address'],
+            $this->sample_connections['connection1']['description'],
+            $this->sample_connections['connection1']['name']
+        );
+
+        $connections = new Connections( array( $connection1 ) );
+        $this->assertCount( 1, $connections->all() );
+    }
+
+    /**
+     * @testdox It should filter out non-Connection objects from constructor.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::__construct
+     */
+    public function test_constructor_filters_invalid_objects(): void {
+        $connection = new Connection( 'key', 'api', 'secret', 'mac', 'desc', 'name' );
+        $invalid_objects = array( $connection, 'string', 123, array(), new \stdClass() );
+
+        $connections = new Connections( $invalid_objects );
+        $this->assertCount( 1, $connections->all() );
+    }
+
+    /**
+     * @testdox It should create Connections from array data with required fields.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::from_array
+     */
+    public function test_can_create_from_array(): void {
+        $data = array(
+            $this->sample_connections['connection1'],
+            $this->sample_connections['connection2'],
+        );
+
+        $connections = Connections::from_array( $data );
+        $this->assertInstanceOf( Connections::class, $connections );
+        $this->assertCount( 2, $connections->all() );
+    }
+
+    /**
+     * @testdox It should handle missing optional fields when creating from array.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::from_array
+     */
+    public function test_from_array_handles_missing_optional_fields(): void {
+        $data = array(
+            array(
+                'key'         => 'test_key',
+                'api_key'     => 'test_api',
+                'api_secret'  => 'test_secret',
+                'mac_address' => '00:11:22:33:44:55',
+                // Missing description and name
+            ),
+        );
+
+        $connections = Connections::from_array( $data );
+        $this->assertCount( 1, $connections->all() );
+        
+        $connection = $connections->get( 'test_key' );
+        $this->assertInstanceOf( Connection::class, $connection );
+        $this->assertSame( '', $connection->description() );
+        $this->assertSame( '', $connection->name() );
+    }
+
+    /**
+     * @testdox It should filter out invalid array data when creating from array.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::from_array
+     */
+    public function test_from_array_filters_invalid_data(): void {
+        $data = array(
+            $this->sample_connections['connection1'], // Valid
+            'invalid_string',                          // Invalid - not array
+            array( 'key' => 'incomplete' ),           // Invalid - missing required fields
+            array(                                     // Invalid - missing required fields
+                'key'        => 'test',
+                'api_key'    => 'test',
+                // Missing api_secret and mac_address
+            ),
+            $this->sample_connections['connection2'], // Valid
+        );
+
+        $connections = Connections::from_array( $data );
+        $this->assertCount( 2, $connections->all() );
+    }
+
+    /**
+     * @testdox It should be possible to add a new connection.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::add
+     */
+    public function test_can_add_connection(): void {
+        $connections = new Connections();
+        
+        $connections->add(
+            $this->sample_connections['connection1']['key'],
+            $this->sample_connections['connection1']['api_key'],
+            $this->sample_connections['connection1']['api_secret'],
+            $this->sample_connections['connection1']['mac_address'],
+            $this->sample_connections['connection1']['description'],
+            $this->sample_connections['connection1']['name']
+        );
+
+        $this->assertCount( 1, $connections->all() );
+        $this->assertTrue( $connections->has( $this->sample_connections['connection1']['key'] ) );
+    }
+
+    /**
+     * @testdox It should be possible to add a connection with default optional parameters.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::add
+     */
+    public function test_can_add_connection_with_defaults(): void {
+        $connections = new Connections();
+        
+        $connections->add( 'key', 'api', 'secret', 'mac' );
+
+        $this->assertCount( 1, $connections->all() );
+        $connection = $connections->get( 'key' );
+        $this->assertSame( '', $connection->description() );
+        $this->assertSame( '', $connection->name() );
+    }
+
+    /**
+     * @testdox It should find the correct index for a connection by key.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::index
+     */
+    public function test_can_find_connection_index(): void {
+        $connections = new Connections();
+        $connections->add( 'first', 'api1', 'secret1', 'mac1' );
+        $connections->add( 'second', 'api2', 'secret2', 'mac2' );
+
+        $this->assertSame( 0, $connections->index( 'first' ) );
+        $this->assertSame( 1, $connections->index( 'second' ) );
+        $this->assertNull( $connections->index( 'nonexistent' ) );
+    }
+
+    /**
+     * @testdox It should correctly check if a connection exists.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::has
+     */
+    public function test_can_check_if_connection_exists(): void {
+        $connections = new Connections();
+        $connections->add( 'existing_key', 'api', 'secret', 'mac' );
+
+        $this->assertTrue( $connections->has( 'existing_key' ) );
+        $this->assertFalse( $connections->has( 'nonexistent_key' ) );
+    }
+
+    /**
+     * @testdox It should retrieve a connection by key.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::get
+     */
+    public function test_can_get_connection_by_key(): void {
+        $connections = new Connections();
+        $connections->add(
+            $this->sample_connections['connection1']['key'],
+            $this->sample_connections['connection1']['api_key'],
+            $this->sample_connections['connection1']['api_secret'],
+            $this->sample_connections['connection1']['mac_address'],
+            $this->sample_connections['connection1']['description'],
+            $this->sample_connections['connection1']['name']
+        );
+
+        $connection = $connections->get( $this->sample_connections['connection1']['key'] );
+        $this->assertInstanceOf( Connection::class, $connection );
+        $this->assertSame( $this->sample_connections['connection1']['key'], $connection->key() );
+    }
+
+    /**
+     * @testdox It should return null when getting a non-existent connection.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::get
+     */
+    public function test_get_returns_null_for_nonexistent_connection(): void {
+        $connections = new Connections();
+        $this->assertNull( $connections->get( 'nonexistent' ) );
+    }
+
+    /**
+     * @testdox It should return all connections as an array.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::all
+     */
+    public function test_can_get_all_connections(): void {
+        $connections = new Connections();
+        $connections->add( 'key1', 'api1', 'secret1', 'mac1' );
+        $connections->add( 'key2', 'api2', 'secret2', 'mac2' );
+
+        $all = $connections->all();
+        $this->assertIsArray( $all );
+        $this->assertCount( 2, $all );
+        
+        foreach ( $all as $connection ) {
+            $this->assertInstanceOf( Connection::class, $connection );
+        }
+    }
+
+    /**
+     * @testdox It should remove a connection by key.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::remove
+     */
+    public function test_can_remove_connection(): void {
+        $connections = new Connections();
+        $connections->add( 'key1', 'api1', 'secret1', 'mac1' );
+        $connections->add( 'key2', 'api2', 'secret2', 'mac2' );
+
+        $this->assertCount( 2, $connections->all() );
+        $this->assertTrue( $connections->has( 'key1' ) );
+
+        $connections->remove( 'key1' );
+
+        $this->assertCount( 1, $connections->all() );
+        $this->assertFalse( $connections->has( 'key1' ) );
+        $this->assertTrue( $connections->has( 'key2' ) );
+    }
+
+    /**
+     * @testdox It should handle removing a non-existent connection gracefully.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::remove
+     */
+    public function test_remove_handles_nonexistent_connection(): void {
+        $connections = new Connections();
+        $connections->add( 'existing', 'api', 'secret', 'mac' );
+
+        $this->assertCount( 1, $connections->all() );
+        
+        // Should not throw error or change anything
+        $connections->remove( 'nonexistent' );
+        
+        $this->assertCount( 1, $connections->all() );
+        $this->assertTrue( $connections->has( 'existing' ) );
+    }
+
+    /**
+     * @testdox It should implement JsonSerializable and return connections array.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::jsonSerialize
+     */
+    public function test_implements_json_serializable(): void {
+        $connections = new Connections();
+        $connections->add( 'key1', 'api1', 'secret1', 'mac1', 'desc1', 'name1' );
+        $connections->add( 'key2', 'api2', 'secret2', 'mac2', 'desc2', 'name2' );
+
+        $this->assertInstanceOf( \JsonSerializable::class, $connections );
+
+        $serialized = $connections->jsonSerialize();
+        $this->assertIsArray( $serialized );
+        $this->assertCount( 2, $serialized );
+        
+        foreach ( $serialized as $connection ) {
+            $this->assertInstanceOf( Connection::class, $connection );
+        }
+    }
+
+    /**
+     * @testdox It should be possible to JSON encode the Connections object.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::jsonSerialize
+     */
+    public function test_can_json_encode_connections(): void {
+        $connections = new Connections();
+        $connections->add(
+            $this->sample_connections['connection1']['key'],
+            $this->sample_connections['connection1']['api_key'],
+            $this->sample_connections['connection1']['api_secret'],
+            $this->sample_connections['connection1']['mac_address'],
+            $this->sample_connections['connection1']['description'],
+            $this->sample_connections['connection1']['name']
+        );
+
+        $json = json_encode( $connections );
+        $this->assertIsString( $json );
+        $this->assertNotFalse( $json );
+
+        $decoded = json_decode( $json, true );
+        $this->assertIsArray( $decoded );
+        $this->assertCount( 1, $decoded );
+        
+        // Check the structure of the decoded connection
+        $connection_data = $decoded[0];
+        $this->assertArrayHasKey( 'key', $connection_data );
+        $this->assertArrayHasKey( 'api_key', $connection_data );
+        $this->assertArrayHasKey( 'api_secret', $connection_data );
+        $this->assertArrayHasKey( 'mac_address', $connection_data );
+        $this->assertArrayHasKey( 'description', $connection_data );
+        $this->assertArrayHasKey( 'name', $connection_data );
+    }
+
+    /**
+     * @testdox It should maintain array indexes after removal operations.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::remove
+     */
+    public function test_array_indexing_after_removal(): void {
+        $connections = new Connections();
+        $connections->add( 'first', 'api1', 'secret1', 'mac1' );
+        $connections->add( 'second', 'api2', 'secret2', 'mac2' );
+        $connections->add( 'third', 'api3', 'secret3', 'mac3' );
+
+        // Remove middle connection
+        $connections->remove( 'second' );
+
+        $this->assertCount( 2, $connections->all() );
+        $this->assertTrue( $connections->has( 'first' ) );
+        $this->assertFalse( $connections->has( 'second' ) );
+        $this->assertTrue( $connections->has( 'third' ) );
+
+        // Verify we can still access remaining connections
+        $this->assertInstanceOf( Connection::class, $connections->get( 'first' ) );
+        $this->assertInstanceOf( Connection::class, $connections->get( 'third' ) );
+    }
+
+    /**
+     * @testdox It should escape HTML in array data when creating from array.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::from_array
+     */
+    public function test_from_array_escapes_html(): void {
+        $malicious_data = array(
+            array(
+                'key'         => '<script>alert("xss")</script>',
+                'api_key'     => '">alert("xss")<',
+                'api_secret'  => '&lt;script&gt;',
+                'mac_address' => '"onclick="alert(1)"',
+                'description' => '<img src=x onerror=alert(1)>',
+                'name'        => '<b>bold</b>',
+            ),
+        );
+
+        $connections = Connections::from_array( $malicious_data );
+        $connection = $connections->get( esc_attr( '<script>alert("xss")</script>' ) );
+
+        $this->assertInstanceOf( Connection::class, $connection );
+        // Verify all values are properly escaped
+        $this->assertSame( esc_attr( $malicious_data[0]['key'] ), $connection->key() );
+        $this->assertSame( esc_attr( $malicious_data[0]['api_key'] ), $connection->api_key() );
+        $this->assertSame( esc_attr( $malicious_data[0]['api_secret'] ), $connection->api_secret() );
+        $this->assertSame( esc_attr( $malicious_data[0]['mac_address'] ), $connection->mac_address() );
+        $this->assertSame( esc_attr( $malicious_data[0]['description'] ), $connection->description() );
+        $this->assertSame( esc_attr( $malicious_data[0]['name'] ), $connection->name() );
+    }
+
+    /**
+     * @testdox It should handle complex workflow of adding, getting, and removing connections.
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::add
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::get
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::remove
+     * @covers \PinkCrab\Ecowitt_Weather_Block\Ecowitt\Api\Connection\Connections::has
+     */
+    public function test_complex_workflow(): void {
+        $connections = new Connections();
+
+        // Add multiple connections
+        foreach ( $this->sample_connections as $data ) {
+            $connections->add(
+                $data['key'],
+                $data['api_key'],
+                $data['api_secret'],
+                $data['mac_address'],
+                $data['description'],
+                $data['name']
+            );
+        }
+
+        $this->assertCount( 2, $connections->all() );
+
+        // Verify both exist
+        $this->assertTrue( $connections->has( 'conn_1' ) );
+        $this->assertTrue( $connections->has( 'conn_2' ) );
+
+        // Get and verify connection details
+        $conn1 = $connections->get( 'conn_1' );
+        $this->assertSame( 'api_key_1', $conn1->api_key() );
+        $this->assertSame( 'First weather station', $conn1->description() );
+
+        // Remove one connection
+        $connections->remove( 'conn_1' );
+        $this->assertCount( 1, $connections->all() );
+        $this->assertFalse( $connections->has( 'conn_1' ) );
+        $this->assertTrue( $connections->has( 'conn_2' ) );
+
+        // Add it back
+        $connections->add( 'conn_1', 'new_api', 'new_secret', 'new_mac', 'Updated desc', 'Updated name' );
+        $this->assertCount( 2, $connections->all() );
+        $this->assertTrue( $connections->has( 'conn_1' ) );
+
+        // Verify updated connection
+        $updated_conn = $connections->get( 'conn_1' );
+        $this->assertSame( 'new_api', $updated_conn->api_key() );
+        $this->assertSame( 'Updated desc', $updated_conn->description() );
+    }
+}

--- a/views/admin/settings/page.php
+++ b/views/admin/settings/page.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * Page template for the settings page.
+ *
+ * @param PinkCrab\Perique\Application\App_Config                    $app_config The App Config.
+ * @param PinkCrab\Ecowitt_Weather_Block\Settings\Page\Settings_Page $page       The Settings Page.
+ * @param PinkCrab\Ecowitt_Weather_Block\Settings\Settings           $settings   The Settings.
+ * @param string                                                     $form_nonce_key The nonce for the form.
+ * @param string                                                     $submission_key The submission key for the form.
+ */
+?>
+<div class="wrap ecowitt-admin">
+	<div class="ecowitt-admin__header">
+		<h1 class="ecowitt-admin__title"><?php echo esc_html( $page->page_title() ); ?></h1>
+	</div>
+	
+	<form method="post" action="<?php echo esc_url( menu_page_url( $page->slug(), false ) ); ?>">
+		<input type="hidden" name="page" value="<?php echo esc_attr( $page->slug() ); ?>" />
+        <input type="hidden" name="<?php echo esc_attr( $submission_key ); ?>" value="1" />
+        <?php wp_nonce_field( $form_nonce_key, $form_nonce_key ); ?>
+		<div class="ecowitt-admin__content">
+			<?php $this->component( $connections ); ?> 
+			
+			<?php submit_button(); ?>
+		</div>
+	</form>
+</div>

--- a/views/admin/settings/page.php
+++ b/views/admin/settings/page.php
@@ -9,6 +9,7 @@
  * @param string                                                     $form_nonce_key The nonce for the form.
  * @param string                                                     $submission_key The submission key for the form.
  */
+dump( get_defined_vars() );
 ?>
 <div class="wrap ecowitt-admin">
 	<div class="ecowitt-admin__header">
@@ -17,8 +18,8 @@
 	
 	<form method="post" action="<?php echo esc_url( menu_page_url( $page->slug(), false ) ); ?>">
 		<input type="hidden" name="page" value="<?php echo esc_attr( $page->slug() ); ?>" />
-        <input type="hidden" name="<?php echo esc_attr( $submission_key ); ?>" value="1" />
-        <?php wp_nonce_field( $form_nonce_key, $form_nonce_key ); ?>
+		<input type="hidden" name="<?php echo esc_attr( $submission_key ); ?>" value="1" />
+		<?php wp_nonce_field( $form_nonce_key, $form_nonce_key ); ?>
 		<div class="ecowitt-admin__content">
 			<?php $this->component( $connections ); ?> 
 			

--- a/views/components/admin/settings/connection.php
+++ b/views/components/admin/settings/connection.php
@@ -1,0 +1,207 @@
+<?php 
+
+/**
+ * Component: Connection 
+ * 
+ * @var PinkCrab\Ecowitt_Weather_Block\View\Component\Settings\Connections\Settings_Connection $connection
+ */
+
+// Determine connection status (you can enhance this logic based on your needs)
+$connection_status = !empty($api_key) && !empty($api_secret) && !empty($mac_address) ? 'active' : 'inactive';
+$connection_id = !empty($key) ? $key : '__new_';
+?>
+
+<div class="connection-card connection--<?php echo esc_attr($connection_status); ?>" id="connection-<?php echo esc_attr($connection_id); ?>">
+    
+    <!-- Connection View State -->
+    <div class="connection__view">
+        <div class="connection__header">
+            <div class="connection__title-group">
+                <h3 class="connection__title">
+                    <?php echo esc_html($name ?: __('Unnamed Connection', 'ecowitt-weather-block')); ?>
+                </h3>
+                <div class="connection__status">
+                    <?php 
+                    if ($connection_status === 'active') {
+                        esc_html_e('Connected', 'ecowitt-weather-block');
+                    } else {
+                        esc_html_e('Not Configured', 'ecowitt-weather-block');
+                    }
+                    ?>
+                </div>
+            </div>
+            
+            <div class="connection__actions">
+                <?php if ($connection_status === 'active') : ?>
+                    <button class="btn btn--sm btn--outline" data-action="edit-connection" data-connection="<?php echo esc_attr($connection_id); ?>">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+                        </svg>
+                        <?php esc_html_e('Edit', 'ecowitt-weather-block'); ?>
+                    </button>
+                    <button class="btn btn--sm btn--danger btn--outline" data-action="delete-connection" data-connection="<?php echo esc_attr($connection_id); ?>">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="3,6 5,6 21,6"></polyline>
+                            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                        </svg>
+                        <?php esc_html_e('Delete', 'ecowitt-weather-block'); ?>
+                    </button>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <div class="connection__content">
+            <?php if (!empty($description)) : ?>
+                <p class="connection__description"><?php echo esc_html($description); ?></p>
+            <?php endif; ?>
+
+            <div class="connection__details">
+                <?php if (!empty($api_key)) : ?>
+                    <div class="connection__detail">
+                        <span class="detail__label"><?php esc_html_e('API Key:', 'ecowitt-weather-block'); ?></span>
+                        <code class="detail__value detail__value--masked" title="<?php echo esc_attr(substr($api_key, 0, 4) . '••••••••'); ?>">
+                            <?php echo esc_html(substr($api_key, 0, 4) . '••••••••'); ?>
+                        </code>
+                    </div>
+                <?php endif; ?>
+
+                <?php if (!empty($api_secret)) : ?>
+                    <div class="connection__detail">
+                        <span class="detail__label"><?php esc_html_e('API Secret:', 'ecowitt-weather-block'); ?></span>
+                        <code class="detail__value detail__value--masked" title="<?php echo esc_attr(substr($api_secret, 0, 4) . '••••••••'); ?>">
+                            <?php echo esc_html(substr($api_secret, 0, 4) . '••••••••'); ?>
+                        </code>
+                    </div>
+                <?php endif; ?>
+
+                <?php if (!empty($mac_address)) : ?>
+                    <div class="connection__detail">
+                        <span class="detail__label"><?php esc_html_e('MAC Address:', 'ecowitt-weather-block'); ?></span>
+                        <code class="detail__value"><?php echo esc_html($mac_address); ?></code>
+                    </div>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <?php if ($connection_status === 'active') : ?>
+            <div class="connection__footer">
+                <div class="connection__meta">
+                    <span class="meta-item">
+                        <strong><?php esc_html_e('Last Updated:', 'ecowitt-weather-block'); ?></strong>
+                        <?php echo esc_html(date_i18n(get_option('date_format'), time())); ?>
+                    </span>
+                </div>
+            </div>
+        <?php endif; ?>
+    </div>
+
+    <!-- Connection Edit State -->
+    <div class="connection__edit" style="display: none;">
+        <div class="connection__form">
+            <input type="hidden" name="connection_key[<?php echo esc_attr($connection_id); ?>]" value="<?php echo esc_attr($key); ?>">
+            
+            <div class="form-grid">
+                <div class="form-group">
+                    <label class="form-label form-label--required" for="connection-<?php echo esc_attr($connection_id); ?>-name">
+                        <?php esc_html_e('Connection Name', 'ecowitt-weather-block'); ?>
+                    </label>
+                    <input type="text" 
+                           class="form-control" 
+                           id="connection-<?php echo esc_attr($connection_id); ?>-name" 
+                           name="connection_name[<?php echo esc_attr($connection_id); ?>]" 
+                           value="<?php echo esc_attr($name); ?>" 
+                           placeholder="<?php esc_attr_e('My Weather Station', 'ecowitt-weather-block'); ?>">
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label form-label--optional" for="connection-<?php echo esc_attr($connection_id); ?>-description">
+                        <?php esc_html_e('Description', 'ecowitt-weather-block'); ?>
+                    </label>
+                    <input type="text" 
+                           class="form-control" 
+                           id="connection-<?php echo esc_attr($connection_id); ?>-description" 
+                           name="connection_description[<?php echo esc_attr($connection_id); ?>]" 
+                           value="<?php echo esc_attr($description); ?>" 
+                           placeholder="<?php esc_attr_e('Weather station in my backyard', 'ecowitt-weather-block'); ?>">
+                </div>
+            </div>
+
+            <div class="form-grid">
+                <div class="form-group">
+                    <label class="form-label form-label--required" for="connection-<?php echo esc_attr($connection_id); ?>-api_key">
+                        <?php esc_html_e('API Key', 'ecowitt-weather-block'); ?>
+                    </label>
+                    <input type="text" 
+                           class="form-control" 
+                           id="connection-<?php echo esc_attr($connection_id); ?>-api_key" 
+                           name="connection_api_key[<?php echo esc_attr($connection_id); ?>]" 
+                           value="<?php echo esc_attr($api_key); ?>"
+                           placeholder="<?php esc_attr_e('Your Ecowitt API Key', 'ecowitt-weather-block'); ?>">
+                    <p class="form-help">
+                        <?php esc_html_e('Get your API key from your Ecowitt account dashboard.', 'ecowitt-weather-block'); ?>
+                    </p>
+                </div>
+
+                <div class="form-group">
+                    <label class="form-label form-label--required" for="connection-<?php echo esc_attr($connection_id); ?>-api_secret">
+                        <?php esc_html_e('API Secret', 'ecowitt-weather-block'); ?>
+                    </label>
+                    <input type="password" 
+                           class="form-control" 
+                           id="connection-<?php echo esc_attr($connection_id); ?>-api_secret" 
+                           name="connection_api_secret[<?php echo esc_attr($connection_id); ?>]" 
+                           value="<?php echo esc_attr($api_secret); ?>"
+                           placeholder="<?php esc_attr_e('Your Ecowitt API Secret', 'ecowitt-weather-block'); ?>">
+                    <p class="form-help">
+                        <?php esc_html_e('Keep your API secret secure and do not share it publicly.', 'ecowitt-weather-block'); ?>
+                    </p>
+                </div>
+            </div>
+
+            <div class="form-grid form-grid--single">
+                <div class="form-group">
+                    <label class="form-label form-label--required" for="connection-<?php echo esc_attr($connection_id); ?>-mac_address">
+                        <?php esc_html_e('MAC Address', 'ecowitt-weather-block'); ?>
+                    </label>
+                    <input type="text" 
+                           class="form-control" 
+                           id="connection-<?php echo esc_attr($connection_id); ?>-mac_address" 
+                           name="connection_mac_address[<?php echo esc_attr($connection_id); ?>]" 
+                           value="<?php echo esc_attr($mac_address); ?>"
+                           placeholder="<?php esc_attr_e('AA:BB:CC:DD:EE:FF', 'ecowitt-weather-block'); ?>"
+                           >
+                    <p class="form-help">
+                        00:1A:2B:3C:4D:5E
+                        <?php esc_html_e('The MAC address of your weather station device.', 'ecowitt-weather-block'); ?>
+                    </p>
+                </div>
+            </div>
+
+            <div class="form-actions">
+                <button type="button" class="btn btn--success" name="save_connection" data-action="save-connection">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"></path>
+                        <polyline points="17,21 17,13 7,13 7,21"></polyline>
+                        <polyline points="7,3 7,8 15,8"></polyline>
+                    </svg>
+                    <?php esc_html_e('Save Connection', 'ecowitt-weather-block'); ?>
+                </button>
+                
+                <button type="button" class="btn btn--secondary" data-action="cancel-edit" data-connection="<?php echo esc_attr($connection_id); ?>">
+                    <?php esc_html_e('Cancel', 'ecowitt-weather-block'); ?>
+                </button>
+
+                <?php if (!empty($key)) : ?>
+                    <button type="button" class="btn btn--danger btn--outline ml-auto" data-action="delete-connection" data-connection="<?php echo esc_attr($connection_id); ?>">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="3,6 5,6 21,6"></polyline>
+                            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                        </svg>
+                        <?php esc_html_e('Delete', 'ecowitt-weather-block'); ?>
+                    </button>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>

--- a/views/components/admin/settings/connections.php
+++ b/views/components/admin/settings/connections.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Template: Connections Component
+ * 
+ * @var PinkCrab\Ecowitt_Weather_Block\View\Component\Settings\Connections\Settings_Connections $connections
+ */
+
+use PinkCrab\Ecowitt_Weather_Block\View\Component\Settings\Connections\Settings_Connection;
+
+?>
+
+<div class="ecowitt-settings-section">
+    <div class="ecowitt-settings-section__header">
+        <h2 class="ecowitt-settings-section__title"><?php esc_html_e('Weather Station Connections', 'ecowitt-weather-block'); ?></h2>
+    </div>
+    
+    <div class="ecowitt-settings-section__content">
+        <div class="connections-container">
+        <?php if (!empty($connections)) : ?>
+            <div class="connections-list">
+                <?php foreach ($connections as $connection_key => $connection): ?>
+                    <?php $this->component($connection); ?>
+                <?php endforeach; ?>
+            </div>
+        <?php else : ?>
+        <div class="connections-empty connections-list">
+            <div class="empty-icon">
+                <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                    <path d="M12 2L2 7l10 5 10-5-10-5z"/>
+                    <path d="M2 17l10 5 10-5"/>
+                    <path d="M2 12l10 5 10-5"/>
+                </svg>
+            </div>
+            <h3 class="empty-title"><?php esc_html_e( 'No Connections Found', 'ecowitt-weather-block' ); ?></h3>
+            <p class="empty-description">
+                <?php esc_html_e( 'You haven\'t added any Ecowitt weather station connections yet. Add your first connection to get started.', 'ecowitt-weather-block' ); ?>
+            </p>
+        </div>
+    <?php endif; ?>
+
+    <?php // Debug info - remove in production ?>
+    <?php if (defined('WP_DEBUG') && WP_DEBUG) : ?>
+        <details class="mt-xl">
+            <summary>Debug Information</summary>
+            <?php dump( get_defined_vars() ); ?>
+        </details>
+    <?php endif; ?>
+
+    <?php // New connection section ?>
+    <div class="new-connection" id="new-connection">
+        <div class="new-connection__icon">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="12" y1="5" x2="12" y2="19"></line>
+                <line x1="5" y1="12" x2="19" y2="12"></line>
+            </svg>
+        </div>
+        <h3 class="new-connection__title"><?php esc_html_e( 'Add New Connection', 'ecowitt-weather-block' ); ?></h3>
+        <p class="new-connection__description">
+            <?php esc_html_e( 'Connect your Ecowitt weather station to start displaying weather data in your WordPress site.', 'ecowitt-weather-block' ); ?>
+        </p>
+                <button type="button" 
+                class="btn btn--primary btn--large"
+                data-action="show-new-connection-form">
+            Add New Connection
+        </button>
+    </div>
+
+    <?php // New connection form ?>
+    <div class="new-connection-form" id="new-connection-form" style="display: none;">
+        <div class="form-header">
+            <h3 class="form-title"><?php esc_html_e( 'Add New Connection', 'ecowitt-weather-block' ); ?></h3>
+            <p class="form-description">
+                <?php esc_html_e( 'Enter your Ecowitt weather station details below to create a new connection.', 'ecowitt-weather-block' ); ?>
+            </p>
+        </div>
+        
+        <div class="form-content">
+            <?php $this->component(new Settings_Connection(null)); ?>
+        </div>
+        </div>
+    </div>
+</div>
+</div>


### PR DESCRIPTION
This pull request introduces a new SCSS-based design system for the admin interface, focusing on WordPress compatibility, extensibility, and modern best practices. It adds foundational variables, mixins, and base styles, as well as a new entrypoint for admin styles. Additionally, it includes a small JavaScript change for debugging. The main themes are the establishment of a scalable SCSS architecture and improved maintainability and consistency across the admin UI.

**Design System Foundations:**

* Added `assets/src/scss/abstracts/_variables.scss` with WordPress-compatible CSS custom properties, plugin-specific variables, responsive breakpoints, and component defaults for consistent theming and spacing.
* Added `assets/src/scss/abstracts/_mixins.scss` providing reusable SCSS mixins for responsiveness, layout (flex, grid, aspect ratio), typography utilities, component bases (buttons, cards, forms), and accessibility/utility helpers.

**Base and Utility Styles:**

* Added `assets/src/scss/base/_typography.scss` defining consistent heading, body, link, list, and code styles for the `.ecowitt-admin` scope, along with utility classes for font size, weight, alignment, color, and truncation.

**Entrypoint and Structure:**

* Created `assets/src/scss/admin.scss` as the main SCSS entrypoint, importing all abstracts, base, layout, utility, and component partials to establish a clear and maintainable stylesheet structure.

**Other:**

* Added a `console.log` statement to `dashboard.js` for debugging purposes.